### PR TITLE
Make specifications "stringable"

### DIFF
--- a/src/Collection/Doctrine/ORM/Specification/Normalizer/AntiJoinNormalizer.php
+++ b/src/Collection/Doctrine/ORM/Specification/Normalizer/AntiJoinNormalizer.php
@@ -28,6 +28,14 @@ final class AntiJoinNormalizer implements Normalizer
         return null;
     }
 
+    /**
+     * @param AntiJoin $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('AntiJoin(%s)', $specification->field());
+    }
+
     protected function supportsSpecification(mixed $specification): bool
     {
         return $specification instanceof AntiJoin;

--- a/src/Collection/Doctrine/ORM/Specification/Normalizer/JoinNormalizer.php
+++ b/src/Collection/Doctrine/ORM/Specification/Normalizer/JoinNormalizer.php
@@ -35,6 +35,14 @@ final class JoinNormalizer implements Normalizer, NormalizerAware
         return $this->normalizer()->normalize($join->child(), $context->scopeTo($join->alias()));
     }
 
+    /**
+     * @param Join $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('%sJoin(%s)', \ucfirst($specification->type()), $specification->field());
+    }
+
     protected function supportsSpecification(mixed $specification): bool
     {
         return $specification instanceof Join;

--- a/src/Collection/Doctrine/Specification/Normalizer/CallableNormalizer.php
+++ b/src/Collection/Doctrine/Specification/Normalizer/CallableNormalizer.php
@@ -18,6 +18,14 @@ final class CallableNormalizer extends DoctrineNormalizer
         return $specification($context);
     }
 
+    /**
+     * @param callable $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return '(callable)';
+    }
+
     protected function supportsSpecification(mixed $specification): bool
     {
         return \is_callable($specification);

--- a/src/Collection/Doctrine/Specification/Normalizer/ComparisonNormalizer.php
+++ b/src/Collection/Doctrine/Specification/Normalizer/ComparisonNormalizer.php
@@ -45,6 +45,18 @@ final class ComparisonNormalizer extends DoctrineNormalizer
     }
 
     /**
+     * @param Comparison $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('Compare(%s %s %s)',
+            $specification->field(),
+            self::methodFor($specification),
+            \is_scalar($value = $specification->value()) ? $value : \get_debug_type($value)
+        );
+    }
+
+    /**
      * @return array<class-string, string>
      */
     protected static function classMethodMap(): array

--- a/src/Collection/Doctrine/Specification/Normalizer/CompositeNormalizer.php
+++ b/src/Collection/Doctrine/Specification/Normalizer/CompositeNormalizer.php
@@ -36,6 +36,19 @@ final class CompositeNormalizer extends DoctrineNormalizer implements Normalizer
     }
 
     /**
+     * @param Composite $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        $children = \array_filter(\array_map(
+            fn($child) => $this->normalizer()->stringify($child, $context),
+            $specification->children()
+        ));
+
+        return \sprintf('%s(%s)', self::methodFor($specification), \implode(', ', $children));
+    }
+
+    /**
      * @return array<class-string, string>
      */
     protected static function classMethodMap(): array

--- a/src/Collection/Doctrine/Specification/Normalizer/NullNormalizer.php
+++ b/src/Collection/Doctrine/Specification/Normalizer/NullNormalizer.php
@@ -25,6 +25,14 @@ final class NullNormalizer extends DoctrineNormalizer
     }
 
     /**
+     * @param Field $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('%s(%s)', self::methodFor($specification), $specification->field());
+    }
+
+    /**
      * @return array<class-string, string>
      */
     protected static function classMethodMap(): array

--- a/src/Collection/Doctrine/Specification/Normalizer/OrderByNormalizer.php
+++ b/src/Collection/Doctrine/Specification/Normalizer/OrderByNormalizer.php
@@ -21,6 +21,14 @@ final class OrderByNormalizer extends DoctrineNormalizer
         return null;
     }
 
+    /**
+     * @param OrderBy $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('OrderBy%s(%s)', $specification->direction(), $specification->field());
+    }
+
     protected function supportsSpecification(mixed $specification): bool
     {
         return $specification instanceof OrderBy;

--- a/src/Collection/Specification/Normalizer.php
+++ b/src/Collection/Specification/Normalizer.php
@@ -9,5 +9,7 @@ interface Normalizer
 {
     public function normalize(mixed $specification, mixed $context): mixed;
 
+    public function stringify(mixed $specification, mixed $context): string;
+
     public function supports(mixed $specification, mixed $context): bool;
 }

--- a/src/Collection/Specification/Normalizer/NestedNormalizer.php
+++ b/src/Collection/Specification/Normalizer/NestedNormalizer.php
@@ -20,6 +20,14 @@ final class NestedNormalizer implements Normalizer, NormalizerAware
         return $this->normalizer()->normalize($specification->child(), $context);
     }
 
+    /**
+     * @param Nested $specification
+     */
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return \sprintf('%s(%s)', $specification::class, $this->normalizer()->stringify($specification->child(), $context));
+    }
+
     public function supports(mixed $specification, mixed $context): bool
     {
         return $specification instanceof Nested;

--- a/src/Collection/Specification/SpecificationNormalizer.php
+++ b/src/Collection/Specification/SpecificationNormalizer.php
@@ -25,19 +25,26 @@ final class SpecificationNormalizer implements Normalizer
 
     public function normalize(mixed $specification, mixed $context): mixed
     {
-        if (!$normalizer = $this->getNormalizer($specification, $context)) {
-            throw new \RuntimeException(\sprintf('Specification "%s" with context "%s" does not have a supported normalizer registered.', \get_debug_type($specification), \get_debug_type($context)));
-        }
+        return $this->getNormalizer($specification, $context)->normalize($specification, $context);
+    }
 
-        return $normalizer->normalize($specification, $context);
+    public function stringify(mixed $specification, mixed $context): string
+    {
+        return $this->getNormalizer($specification, $context)->stringify($specification, $context);
     }
 
     public function supports(mixed $specification, mixed $context): bool
     {
-        return null !== $this->getNormalizer($specification, $context);
+        try {
+            $this->getNormalizer($specification, $context);
+
+            return true;
+        } catch (\RuntimeException) {
+            return false;
+        }
     }
 
-    private function getNormalizer(mixed $specification, mixed $context): ?Normalizer
+    private function getNormalizer(mixed $specification, mixed $context): Normalizer
     {
         $specificationCacheKey = \is_object($specification) ? $specification::class : 'native-'.\gettype($specification);
         $contextCacheKey = \is_object($context) ? $context::class : 'native-'.\gettype($context);
@@ -58,6 +65,6 @@ final class SpecificationNormalizer implements Normalizer
             return $this->normalizerCache[$specificationCacheKey][$contextCacheKey] = $normalizer;
         }
 
-        return null;
+        throw new \RuntimeException(\sprintf('Specification "%s" with context "%s" does not have a supported normalizer registered.', \get_debug_type($specification), \get_debug_type($context)));
     }
 }


### PR DESCRIPTION
Closes #6.

- [ ] Tests
- [ ] Use string in `matchOne()` not found exception