### PR TITLE
make specifications "stringable"

### DIFF
--- a/src/Collection/Doctrine/DBAL/Repository/IsMatchable.php
+++ b/src/Collection/Doctrine/DBAL/Repository/IsMatchable.php
@@ -8,6 +8,7 @@ use Zenstruck\Collection\Doctrine\DBAL\Repository;
 use Zenstruck\Collection\Doctrine\DBAL\Result;
 use Zenstruck\Collection\Doctrine\DBAL\Specification\DBALContext;
 use Zenstruck\Collection\Specification\Normalizer;
+use Zenstruck\Collection\Specification\SpecificationNormalizer;
 
 /**
  * Enables your repository to implement Zenstruck\Collection\Matchable.
@@ -46,7 +47,7 @@ trait IsMatchable
         ;
 
         if (!$result) {
-            throw new \RuntimeException(\sprintf('Data from "%s" table not found for given specification.', static::tableName()));
+            throw new \RuntimeException(\sprintf('Data from "%s" table not found for specification "%s".', static::tableName(), SpecificationNormalizer::stringify($specification)));
         }
 
         return $this instanceof ObjectRepository ? static::createObject($result) : $result;

--- a/src/Collection/Doctrine/ORM/Repository/IsMatchable.php
+++ b/src/Collection/Doctrine/ORM/Repository/IsMatchable.php
@@ -7,6 +7,7 @@ use Zenstruck\Collection\Doctrine\ORM\Repository;
 use Zenstruck\Collection\Doctrine\ORM\Result;
 use Zenstruck\Collection\Doctrine\ORM\Specification\ORMContext;
 use Zenstruck\Collection\Specification\Normalizer;
+use Zenstruck\Collection\Specification\SpecificationNormalizer;
 
 /**
  * Enables your repository to implement Zenstruck\Collection\Matchable.
@@ -40,7 +41,7 @@ trait IsMatchable
         }
 
         if (!\is_object($result = $this->qbForSpecification($specification)->getQuery()->getOneOrNullResult())) {
-            throw new \RuntimeException("{$this->getClassName()} not found for given specification.");
+            throw new \RuntimeException(\sprintf('Object "%s" not found for specification "%s".', $this->getClassName(), SpecificationNormalizer::stringify($specification)));
         }
 
         /** @var V $result */

--- a/src/Collection/Doctrine/ORM/Specification/AntiJoin.php
+++ b/src/Collection/Doctrine/ORM/Specification/AntiJoin.php
@@ -9,4 +9,8 @@ use Zenstruck\Collection\Specification\Field;
  */
 final class AntiJoin extends Field
 {
+    public function __toString(): string
+    {
+        return \sprintf('AntiJoin(%s)', $this->field());
+    }
 }

--- a/src/Collection/Doctrine/ORM/Specification/Join.php
+++ b/src/Collection/Doctrine/ORM/Specification/Join.php
@@ -25,6 +25,11 @@ final class Join extends Field
         $this->alias = $alias ?? $field;
     }
 
+    public function __toString(): string
+    {
+        return \sprintf('%sJoin(%s)', \ucfirst($this->type()), $this->field());
+    }
+
     public static function inner(string $field, ?string $alias = null): self
     {
         return new self(self::TYPE_INNER, $field, $alias);

--- a/src/Collection/Specification/Field.php
+++ b/src/Collection/Specification/Field.php
@@ -5,13 +5,18 @@ namespace Zenstruck\Collection\Specification;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-abstract class Field
+abstract class Field implements \Stringable
 {
     private string $field;
 
     public function __construct(string $field)
     {
         $this->field = $field;
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('%s(%s)', (new \ReflectionClass($this))->getShortName(), $this->field());
     }
 
     final public function field(): string

--- a/src/Collection/Specification/Filter/Comparison.php
+++ b/src/Collection/Specification/Filter/Comparison.php
@@ -18,6 +18,21 @@ abstract class Comparison extends Field
         $this->value = $value;
     }
 
+    public function __toString(): string
+    {
+        $value = $this->value();
+
+        if (\is_string($value)) {
+            $value = "'{$value}'";
+        }
+
+        return \sprintf('Compare(%s %s %s)',
+            $this->field(),
+            (new \ReflectionClass($this))->getShortName(),
+            \is_scalar($value) ? $value : \get_debug_type($value)
+        );
+    }
+
     public function value(): mixed
     {
         return $this->value;

--- a/src/Collection/Specification/Logic/Composite.php
+++ b/src/Collection/Specification/Logic/Composite.php
@@ -2,6 +2,8 @@
 
 namespace Zenstruck\Collection\Specification\Logic;
 
+use Zenstruck\Collection\Specification\SpecificationNormalizer;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -13,6 +15,13 @@ abstract class Composite
     public function __construct(mixed ...$children)
     {
         $this->children = $children;
+    }
+
+    public function __toString(): string
+    {
+        $children = \array_filter(\array_map([SpecificationNormalizer::class, 'stringify'], $this->children()));
+
+        return \sprintf('%s(%s)', (new \ReflectionClass($this))->getShortName(), \implode(', ', $children));
     }
 
     /**

--- a/src/Collection/Specification/OrderBy.php
+++ b/src/Collection/Specification/OrderBy.php
@@ -19,6 +19,11 @@ final class OrderBy extends Field
         $this->direction = $direction;
     }
 
+    public function __toString(): string
+    {
+        return \sprintf('OrderBy%s(%s)', $this->direction(), $this->field());
+    }
+
     public static function asc(string $field): self
     {
         return new self($field, self::ASC);

--- a/src/Collection/Specification/SpecificationNormalizer.php
+++ b/src/Collection/Specification/SpecificationNormalizer.php
@@ -26,7 +26,7 @@ final class SpecificationNormalizer implements Normalizer
     public function normalize(mixed $specification, mixed $context): mixed
     {
         if (!$normalizer = $this->getNormalizer($specification, $context)) {
-            throw new \RuntimeException(\sprintf('Specification "%s" with context "%s" does not have a supported normalizer registered.', \get_debug_type($specification), \get_debug_type($context)));
+            throw new \RuntimeException(\sprintf('Specification "%s" with context "%s" does not have a supported normalizer registered.', self::stringify($specification), \get_debug_type($context)));
         }
 
         return $normalizer->normalize($specification, $context);
@@ -35,6 +35,22 @@ final class SpecificationNormalizer implements Normalizer
     public function supports(mixed $specification, mixed $context): bool
     {
         return null !== $this->getNormalizer($specification, $context);
+    }
+
+    /**
+     * Utility method to aid in debugging.
+     */
+    public static function stringify(mixed $specification): string
+    {
+        if ($specification instanceof \Stringable) {
+            return $specification;
+        }
+
+        if ($specification instanceof Nested) {
+            return \sprintf('%s(%s)', $specification::class, self::stringify($specification->child()));
+        }
+
+        return \get_debug_type($specification);
     }
 
     private function getNormalizer(mixed $specification, mixed $context): ?Normalizer

--- a/tests/Specification/SpecificationNormalizerTest.php
+++ b/tests/Specification/SpecificationNormalizerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Zenstruck\Collection\Tests\Specification;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\Doctrine\ORM\Specification\Join;
+use Zenstruck\Collection\Spec;
+use Zenstruck\Collection\Specification\Nested;
+use Zenstruck\Collection\Specification\SpecificationNormalizer;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class SpecificationNormalizerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function throws_exception_if_normalizer_not_found(): void
+    {
+        $normalizer = new SpecificationNormalizer([]);
+
+        $this->assertFalse($normalizer->supports(null, null));
+
+        $this->expectException(\RuntimeException::class);
+
+        $normalizer->normalize(null, null);
+    }
+
+    /**
+     * @test
+     */
+    public function can_stringify_spec(): void
+    {
+        $str = SpecificationNormalizer::stringify(Spec::andX(
+            Spec::orX(Spec::eq('foo', 'bar'), Spec::in('foo', ['bar'])),
+            Spec::sortAsc('foo'),
+            Join::anti('foo'),
+            Join::inner('foo'),
+            new NestedSpec(),
+        ));
+
+        $this->assertSame(
+            \sprintf("AndX(OrX(Compare(foo Equal 'bar'), Compare(foo In array)), OrderByASC(foo), AntiJoin(foo), InnerJoin(foo), %s(Compare(foo Equal 1)))", NestedSpec::class),
+            $str
+        );
+    }
+}
+
+class NestedSpec implements Nested
+{
+    public function child(): mixed
+    {
+        return Spec::eq('foo', 1);
+    }
+}


### PR DESCRIPTION
Alternate to #8. Closes #6.

- [x] Tests
- [x] Use string in `matchOne()` not found exception