### PR TITLE
Add `IterableCollection` helper methods and `ArrayCollection`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "sort-packages": true
     },
     "autoload": {
-        "psr-4": { "Zenstruck\\": ["src/"] }
+        "psr-4": { "Zenstruck\\": ["src/"] },
+        "files": ["src/functions.php"]
     },
     "autoload-dev": {
         "psr-4": { "Zenstruck\\Collection\\Tests\\": ["tests/"] }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,17 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property Zenstruck\\\\Collection\\\\IterableCollection\\<K,V\\>\\:\\:\\$source \\(\\(Closure\\(\\)\\: iterable\\<K, V\\>\\)\\|iterable\\<K, V\\>\\) does not accept \\(callable\\(\\)\\: iterable\\<K, V\\>&Traversable\\<mixed, mixed\\>\\)\\|\\(Closure\\(\\)\\: mixed\\)\\|iterable\\<K, V\\>\\.$#"
+			message: "#^Property Zenstruck\\\\Collection\\\\ArrayCollection\\<K of \\(int\\|string\\),V\\>\\:\\:\\$source \\(array\\<K of \\(int\\|string\\), V\\>\\) does not accept array\\.$#"
+			count: 1
+			path: src/Collection/ArrayCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of static method Closure\\:\\:fromCallable\\(\\) expects callable\\(\\)\\: mixed, array\\|\\(callable\\(\\)\\: iterable\\<K of \\(int\\|string\\), V\\>\\)\\|\\(callable\\(\\)\\: iterable\\<K of \\(int\\|string\\), V\\>&iterable\\)\\|\\(callable\\(\\)\\: iterable\\<K of \\(int\\|string\\), V\\>&iterable\\<K of \\(int\\|string\\), V\\>\\) given\\.$#"
+			count: 1
+			path: src/Collection/IterableCollection.php
+
+		-
+			message: "#^Property Zenstruck\\\\Collection\\\\IterableCollection\\<K of \\(int\\|string\\),V\\>\\:\\:\\$source \\(\\(Closure\\(\\)\\: iterable\\<K of \\(int\\|string\\), V\\>\\)\\|iterable\\<K of \\(int\\|string\\), V\\>\\) does not accept array\\<K, \\*NEVER\\*&V\\>\\|\\(callable\\(\\)\\: iterable\\<K of \\(int\\|string\\), V\\>&Traversable\\<mixed, mixed\\>\\)\\|\\(Closure\\(\\)\\: mixed\\)\\|iterable\\<K of \\(int\\|string\\), V\\>\\.$#"
 			count: 1
 			path: src/Collection/IterableCollection.php
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -5,7 +5,7 @@ namespace Zenstruck;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @extends \IteratorAggregate<K,V>
  */

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Zenstruck\Collection;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template K of array-key
+ * @template V
+ */
+final class ArrayCollection
+{
+    /** @var array<K,V> */
+    private array $source;
+
+    /**
+     * @param iterable<K,V>|callable():iterable<K,V>|null $source
+     */
+    public function __construct(iterable|callable|null $source = null)
+    {
+        $this->source = \is_array($source) ? $source : (new IterableCollection($source))->toArray();
+    }
+
+    /**
+     * @return array<K,V>
+     */
+    public function all(): array
+    {
+        return $this->source;
+    }
+}

--- a/src/Collection/Bridge/PagerfantaAdapter.php
+++ b/src/Collection/Bridge/PagerfantaAdapter.php
@@ -8,7 +8,7 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @implements AdapterInterface<V>
  */

--- a/src/Collection/CallbackCollection.php
+++ b/src/Collection/CallbackCollection.php
@@ -7,7 +7,7 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @implements Collection<K,V>
  */

--- a/src/Collection/FactoryCollection.php
+++ b/src/Collection/FactoryCollection.php
@@ -7,7 +7,7 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @implements Collection<K,V>
  */

--- a/src/Collection/Filterable.php
+++ b/src/Collection/Filterable.php
@@ -7,7 +7,7 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  */
 interface Filterable

--- a/src/Collection/Repository.php
+++ b/src/Collection/Repository.php
@@ -7,7 +7,7 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @extends \IteratorAggregate<K,V>
  */

--- a/src/Collection/Store.php
+++ b/src/Collection/Store.php
@@ -5,7 +5,7 @@ namespace Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
+ * @template K of array-key
  * @template V
  * @extends Repository<K,V>
  */

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zenstruck;
+
+use Zenstruck\Collection\IterableCollection;
+
+/**
+ * @template K of array-key
+ * @template V
+ *
+ * @param iterable<K,V>|callable():iterable<K,V>|null $source
+ *
+ * @return IterableCollection<K,V>
+ */
+function collect(iterable|callable|null $source = null): IterableCollection
+{
+    return new IterableCollection($source);
+}

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Zenstruck\Collection\Tests;
+
+use Zenstruck\Collection\IterableCollection;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ArrayCollectionTest extends IterableCollectionTest
+{
+    /**
+     * @test
+     */
+    public function filter(): void
+    {
+        parent::filter();
+
+        // with no callable
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function reject(): void
+    {
+        parent::reject();
+
+        // with no callable
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function key_by(): void
+    {
+        parent::key_by();
+
+        // with \Stringable object as key
+        $this->markTestIncomplete();
+    }
+
+    public function map_with_keys(): void
+    {
+        parent::map_with_keys();
+
+        // with \Stringable object as key
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function all(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function keys(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function values(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function reverse(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function slice(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function merge(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort_desc(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort_by(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort_by_desc(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort_keys(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function sort_keys_desc(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function combine(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function combine_with_self(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function group_by(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function get(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function set(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function forget(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function only(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function push(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function in(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function key_exists(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function implode(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function array_accessor(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function explode_constructor(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function range_constructor(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function fill_constructor(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * @test
+     */
+    public function fill_keys_constructor(): void
+    {
+        $this->markTestIncomplete();
+    }
+
+    protected function createWithItems(int $count): IterableCollection
+    {
+        // todo use array collection
+        return new IterableCollection($count ? \range(1, $count) : []);
+    }
+}

--- a/tests/CallbackCollectionTest.php
+++ b/tests/CallbackCollectionTest.php
@@ -11,7 +11,7 @@ use Zenstruck\Collection\CallbackCollection;
  */
 final class CallbackCollectionTest extends TestCase
 {
-    use PagintableCollectionTests;
+    use CollectionTests, PagintableCollectionTests;
 
     /**
      * @test

--- a/tests/Doctrine/DBAL/ObjectRepositoryTest.php
+++ b/tests/Doctrine/DBAL/ObjectRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Collection\Tests\Doctrine\DBAL;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\DBAL\Fixture\ObjectRepository;
 use Zenstruck\Collection\Tests\Doctrine\FilterableRepositoryTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
@@ -14,7 +15,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class ObjectRepositoryTest extends TestCase
 {
-    use FilterableRepositoryTests, HasDatabase, PagintableCollectionTests;
+    use CollectionTests, FilterableRepositoryTests, HasDatabase, PagintableCollectionTests;
 
     protected function createWithItems(int $count): ObjectRepository
     {

--- a/tests/Doctrine/DBAL/ObjectResultTest.php
+++ b/tests/Doctrine/DBAL/ObjectResultTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\DBAL;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection;
 use Zenstruck\Collection\Doctrine\DBAL\ObjectResult;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -14,7 +15,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class ObjectResultTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     protected function createWithItems(int $count): Collection
     {

--- a/tests/Doctrine/DBAL/RepositoryTest.php
+++ b/tests/Doctrine/DBAL/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\DBAL;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\DBAL\Fixture\Repository;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -13,7 +14,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class RepositoryTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     protected function createWithItems(int $count): Collection
     {

--- a/tests/Doctrine/DBAL/ResultTest.php
+++ b/tests/Doctrine/DBAL/ResultTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\DBAL;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection;
 use Zenstruck\Collection\Doctrine\DBAL\Result;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -14,7 +15,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class ResultTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     protected function createWithItems(int $count): Collection
     {

--- a/tests/Doctrine/ORM/RepositoryTest.php
+++ b/tests/Doctrine/ORM/RepositoryTest.php
@@ -8,6 +8,7 @@ use Zenstruck\Collection\Doctrine\ORM\Batch\CountableBatchIterator;
 use Zenstruck\Collection\Doctrine\ORM\Batch\CountableBatchProcessor;
 use Zenstruck\Collection\Doctrine\ORM\Specification\Join;
 use Zenstruck\Collection\Spec;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\FilterableRepositoryTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\ManagerRegistryStub;
@@ -21,7 +22,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class RepositoryTest extends TestCase
 {
-    use FilterableRepositoryTests, HasDatabase, PagintableCollectionTests;
+    use CollectionTests, FilterableRepositoryTests, HasDatabase, PagintableCollectionTests;
 
     /**
      * @test

--- a/tests/Doctrine/ORM/Result/ObjectResultTest.php
+++ b/tests/Doctrine/ORM/Result/ObjectResultTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection\Doctrine\ORM\Batch\CountableBatchIterator;
 use Zenstruck\Collection\Doctrine\ORM\Batch\CountableBatchProcessor;
 use Zenstruck\Collection\Doctrine\ORMResult;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -15,7 +16,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 abstract class ObjectResultTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     /**
      * @test

--- a/tests/Doctrine/ORM/Result/QueryExtraFieldsResultTest.php
+++ b/tests/Doctrine/ORM/Result/QueryExtraFieldsResultTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\ORM\Result;
 use Composer\InstalledVersions;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection\Doctrine\ORMResult;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -14,7 +15,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class QueryExtraFieldsResultTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/ORM/Result/QueryFieldsResultTest.php
+++ b/tests/Doctrine/ORM/Result/QueryFieldsResultTest.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\ORM\Result;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection\Doctrine\ORMResult;
+use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\PagintableCollectionTests;
@@ -13,7 +14,7 @@ use Zenstruck\Collection\Tests\PagintableCollectionTests;
  */
 final class QueryFieldsResultTest extends TestCase
 {
-    use HasDatabase, PagintableCollectionTests;
+    use CollectionTests, HasDatabase, PagintableCollectionTests;
 
     /**
      * @test

--- a/tests/DoctrineCollectionTest.php
+++ b/tests/DoctrineCollectionTest.php
@@ -12,7 +12,7 @@ use Zenstruck\Collection\DoctrineCollection;
  */
 abstract class DoctrineCollectionTest extends TestCase
 {
-    use PagintableCollectionTests;
+    use CollectionTests, PagintableCollectionTests;
 
     private ?DoctrineCollection $collection = null;
 

--- a/tests/FactoryCollectionTest.php
+++ b/tests/FactoryCollectionTest.php
@@ -12,7 +12,7 @@ use Zenstruck\Collection\IterableCollection;
  */
 final class FactoryCollectionTest extends TestCase
 {
-    use PagintableCollectionTests;
+    use CollectionTests, PagintableCollectionTests;
 
     protected function createWithItems(int $count): Collection
     {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Zenstruck\Collection\Tests;
+
+use PHPUnit\Framework\TestCase;
+use function Zenstruck\collect;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class FunctionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function collect(): void
+    {
+        $this->assertTrue(collect()->isEmpty());
+    }
+}

--- a/tests/IterableCollectionTest.php
+++ b/tests/IterableCollectionTest.php
@@ -10,7 +10,117 @@ use Zenstruck\Collection\IterableCollection;
  */
 abstract class IterableCollectionTest extends TestCase
 {
-    use PagintableCollectionTests;
+    use CollectionTests, PagintableCollectionTests;
+
+    /**
+     * @test
+     */
+    public function to_array(): void
+    {
+        $items = $this->createWithItems(3);
+
+        $this->assertSame(\iterator_to_array($items), $items->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function filter(): void
+    {
+        $items = $this->createWithItems(3);
+        $arr = $items->toArray();
+
+        $this->assertSame([1 => $arr[1], 2 => $arr[2]], $items->filter(fn($value, $key) => $key > 0)->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function reject(): void
+    {
+        $items = $this->createWithItems(3);
+        $arr = $items->toArray();
+
+        $this->assertSame([0 => $arr[0]], $items->reject(fn($value, $key) => $key > 0)->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function key_by(): void
+    {
+        $items = $this->createWithItems(3);
+
+        $this->assertSame(['k0', 'k1', 'k2'], \array_keys($items->keyBy(fn($value, $key) => 'k'.$key)->toArray()));
+    }
+
+    /**
+     * @test
+     */
+    public function map(): void
+    {
+        $items = $this->createWithItems(3);
+
+        $this->assertSame(['v0', 'v1', 'v2'], $items->map(fn($value, $key) => 'v'.$key)->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function map_with_keys(): void
+    {
+        $items = $this->createWithItems(3);
+
+        $this->assertSame(
+            ['k0' => 'v0', 'k1' => 'v1', 'k2' => 'v2'],
+            $items->mapWithKeys(fn($value, $key) => yield 'k'.$key => 'v'.$key)->toArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function first(): void
+    {
+        $items = $this->createWithItems(2);
+
+        $this->assertSame($items->toArray()[0], $items->first());
+        $this->assertSame($items->toArray()[0], $items->first('foo'));
+        $this->assertNull($this->createWithItems(0)->first());
+        $this->assertSame('foo', $this->createWithItems(0)->first('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function first_where(): void
+    {
+        $items = $this->createWithItems(2);
+
+        $this->assertSame($items->toArray()[1], $items->firstWhere(fn($value, $key) => $key > 0));
+        $this->assertSame($items->toArray()[1], $items->firstWhere(fn($value, $key) => $key > 0), 'foo');
+        $this->assertNull($items->firstWhere(fn($value, $key) => $key > 10));
+        $this->assertSame('foo', $items->firstWhere(fn($value, $key) => $key > 10, 'foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function is_empty(): void
+    {
+        $this->assertTrue($this->createWithItems(0)->isEmpty());
+        $this->assertFalse($this->createWithItems(2)->isEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function eager(): void
+    {
+        $items = $this->createWithItems(3);
+
+        $this->assertSame($items->toArray(), $items->eager()->all());
+    }
 
     abstract protected function createWithItems(int $count): IterableCollection;
 }

--- a/tests/PagintableCollectionTests.php
+++ b/tests/PagintableCollectionTests.php
@@ -7,8 +7,6 @@ namespace Zenstruck\Collection\Tests;
  */
 trait PagintableCollectionTests
 {
-    use CollectionTests;
-
     /**
      * @test
      */


### PR DESCRIPTION
- [x] `Zenstruck\collect()` function
- [ ] Have `Doctrine\ORM\Result` extend `IterableCollection` (#19)
- [ ] `Doctrine\ORM\Result` tests extend `IterableCollectionTest`
- [ ] _array-specific_ optimizations for `ArrayCollection`
- [x] `ORM\Result::eager(): ArrayCollection` - use `ORM\Result::toArray()`!