### PR TITLE
alternate repository system

### DIFF
--- a/src/Collection/Doctrine/EntityRepository.php
+++ b/src/Collection/Doctrine/EntityRepository.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository as ORMEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use Zenstruck\Collection\Doctrine\ORM\Result;
+use Zenstruck\Collection\Doctrine\ORM\ResultQueryBuilder;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template V of object
+ * @implements ObjectRepository<V>
+ */
+class EntityRepository implements ObjectRepository
+{
+    /** @var ORMEntityRepository<V> */
+    private ORMEntityRepository $ormRepo;
+
+    /**
+     * @param class-string<V>|null $class
+     */
+    public function __construct(private ManagerRegistry|EntityManagerInterface $registry, private ?string $class = null)
+    {
+    }
+
+    public function get(mixed $specification): object
+    {
+        return $this->find($specification) ?? throw new \RuntimeException('todo');
+    }
+
+    public function find(mixed $specification): ?object
+    {
+        return $this->ormRepo()->find($specification);
+    }
+
+    /**
+     * @param array<string,scalar> $specification
+     *
+     * @return Result<V>
+     */
+    public function filter(mixed $specification): Result
+    {
+        if (!\is_array($specification)) {
+            throw new \LogicException();
+        }
+
+        $qb = $this->qb('e');
+
+        foreach ($specification as $field => $value) {
+            $qb->andWhere("e.{$field} = :{$field}")->setParameter($field, $value);
+        }
+
+        return $qb->result();
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return $this->qb('e')->result()->batch();
+    }
+
+    public function count(): int
+    {
+        return $this->qb('e')->result()->count();
+    }
+
+    /**
+     * @return ResultQueryBuilder<V>
+     */
+    protected function qb(string $alias, ?string $indexBy = null): ResultQueryBuilder
+    {
+        return (new ResultQueryBuilder($this->em()))
+            ->select($alias)
+            ->from($this->entityClass(), $alias, $indexBy)
+        ;
+    }
+
+    final protected function em(): EntityManagerInterface
+    {
+        if ($this->registry instanceof EntityManagerInterface) {
+            return $this->registry;
+        }
+
+        if (!($em = $this->registry->getManagerForClass($this->entityClass())) instanceof EntityManagerInterface) {
+            throw new \LogicException();
+        }
+
+        return $this->registry = $em;
+    }
+
+    /**
+     * @return ORMEntityRepository<V>
+     */
+    final protected function ormRepo(): ORMEntityRepository
+    {
+        return $this->ormRepo ??= $this->em()->getRepository($this->entityClass());
+    }
+
+    /**
+     * @return class-string<V>
+     */
+    private function entityClass(): string
+    {
+        if ($this->class) {
+            return $this->class;
+        }
+
+        if ($attribute = (new \ReflectionClass(static::class))->getAttributes(ForClass::class)[0] ?? null) {
+            return $this->class = $attribute->newInstance()->name; // @phpstan-ignore-line
+        }
+
+        throw new \LogicException();
+    }
+}

--- a/src/Collection/Doctrine/EntityRepositoryFactory.php
+++ b/src/Collection/Doctrine/EntityRepositoryFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class EntityRepositoryFactory implements ObjectRepositoryFactory
+{
+    /** @var array<class-string,EntityRepository<object>> */
+    private array $cache = [];
+
+    /**
+     * @param ContainerInterface|array<class-string,EntityRepository<object>> $locator
+     * @param class-string<EntityRepository<object>>                          $defaultEntityRepository
+     */
+    public function __construct(
+        private ManagerRegistry $registry,
+        private ContainerInterface|array $locator = [],
+        private string $defaultEntityRepository = EntityRepository::class,
+    ) {
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return EntityRepository<T>
+     */
+    public function create(string $class): EntityRepository
+    {
+        if (isset($this->cache[$class])) {
+            return $this->cache[$class]; // @phpstan-ignore-line
+        }
+
+        if ($repo = $this->locate($class)) {
+            return $this->cache[$class] = $repo; // @phpstan-ignore-line
+        }
+
+        if (!($em = $this->registry->getManagerForClass($class)) instanceof EntityManagerInterface) {
+            throw new \LogicException();
+        }
+
+        return $this->cache[$class] = new ($this->defaultEntityRepository)($em, $class); // @phpstan-ignore-line
+    }
+
+    /**
+     * @param class-string $class
+     *
+     * @return EntityRepository<object>|null
+     */
+    private function locate(string $class): ?EntityRepository
+    {
+        if (\is_array($this->locator)) {
+            return $this->locator[$class] ?? null;
+        }
+
+        try {
+            return $this->locator->get($class);
+        } catch (NotFoundExceptionInterface) {
+            return null;
+        }
+    }
+}

--- a/src/Collection/Doctrine/ForClass.php
+++ b/src/Collection/Doctrine/ForClass.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @readonly
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final class ForClass
+{
+    /**
+     * @param class-string $name
+     */
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Collection/Doctrine/ObjectRepository.php
+++ b/src/Collection/Doctrine/ObjectRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+use Zenstruck\Collection\Repository;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template V of object
+ * @extends Repository<V>
+ */
+interface ObjectRepository extends Repository
+{
+    public function get(mixed $specification): object;
+
+    public function find(mixed $specification): ?object;
+}

--- a/src/Collection/Doctrine/ObjectRepositoryFactory.php
+++ b/src/Collection/Doctrine/ObjectRepositoryFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface ObjectRepositoryFactory
+{
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     *
+     * @return ObjectRepository<T>
+     */
+    public function create(string $class): ObjectRepository;
+}

--- a/src/Collection/Repository.php
+++ b/src/Collection/Repository.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection;
+
+use Zenstruck\Collection;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template V
+ * @extends \IteratorAggregate<array-key,V>
+ */
+interface Repository extends \IteratorAggregate, \Countable
+{
+    /**
+     * @return V
+     *
+     * @throws \RuntimeException If no result
+     */
+    public function get(mixed $specification): mixed;
+
+    /**
+     * @return V|null
+     */
+    public function find(mixed $specification): mixed;
+
+    /**
+     * @return Collection<array-key,V>
+     */
+    public function filter(mixed $specification): Collection;
+}


### PR DESCRIPTION
TODO:
- [ ] Have `ForClass` attribute extend Symfony's `Autowire` (if available) to allow easily injecting generic object repositories
    ```php
    public function someAction(#[ForClass(Post::class)] EntityRepository $repo): Response
    ```
- [ ] Add basic _callable_ specification system
- [ ] customize not found exception 
- [ ] "repository tests"
- [ ] Symfony bundle
- [ ] writable repository and result