### PR TITLE
feat: Specification system

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "doctrine/collections": "^2.1",
         "doctrine/dbal": "^2.12|^3.0",
         "doctrine/doctrine-bundle": "^2.4",
-        "doctrine/orm": "^2.11",
+        "doctrine/orm": "^2.15",
         "pagerfanta/pagerfanta": "^1.0|^2.0|^3.0",
         "phpstan/phpstan": "^1.4",
         "phpunit/phpunit": "^9.5.0",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -12,6 +12,7 @@
 namespace Zenstruck;
 
 use Zenstruck\Collection\ArrayCollection;
+use Zenstruck\Collection\Exception\InvalidSpecification;
 use Zenstruck\Collection\Page;
 use Zenstruck\Collection\Pages;
 
@@ -28,11 +29,13 @@ use Zenstruck\Collection\Pages;
 interface Collection extends \IteratorAggregate, \Countable
 {
     /**
-     * @param callable(V,K):bool $predicate
+     * @param mixed|callable(V,K):bool $specification
      *
      * @return self<K,V>
+     *
+     * @throws InvalidSpecification if $specification is not valid
      */
-    public function filter(callable $predicate): self;
+    public function filter(mixed $specification): self;
 
     /**
      * @template T
@@ -69,12 +72,14 @@ interface Collection extends \IteratorAggregate, \Countable
     /**
      * @template D
      *
-     * @param callable(V,K):bool $predicate
-     * @param D                  $default
+     * @param mixed|callable(V,K):bool $specification
+     * @param D                        $default
      *
      * @return V|D
+     *
+     * @throws InvalidSpecification if $specification is not a valid specification
      */
-    public function find(callable $predicate, mixed $default = null): mixed;
+    public function find(mixed $specification, mixed $default = null): mixed;
 
     /**
      * @template T

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Collection;
 
 use Zenstruck\Collection;
+use Zenstruck\Collection\Exception\InvalidSpecification;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -179,13 +180,17 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @param null|callable(V,K):bool $predicate
+     * @param null|callable(V,K):bool $specification
      *
      * @return self<K,V>
      */
-    public function filter(?callable $predicate = null): self
+    public function filter(mixed $specification = null): self
     {
-        return new self(\array_filter($this->source, $predicate, \ARRAY_FILTER_USE_BOTH));
+        if (null !== $specification && !\is_callable($specification)) {
+            throw InvalidSpecification::build($specification, self::class, 'filter', 'Only null|callable(V,K):bool is supported.');
+        }
+
+        return new self(\array_filter($this->source, $specification, \ARRAY_FILTER_USE_BOTH));
     }
 
     /**

--- a/src/Collection/Doctrine/DoctrineSpec.php
+++ b/src/Collection/Doctrine/DoctrineSpec.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine;
+
+use Zenstruck\Collection\Doctrine\ORM\Specification\AntiJoin;
+use Zenstruck\Collection\Doctrine\ORM\Specification\Join;
+use Zenstruck\Collection\Doctrine\Specification\Cache;
+use Zenstruck\Collection\Doctrine\Specification\Delete;
+use Zenstruck\Collection\Doctrine\Specification\Instance;
+use Zenstruck\Collection\Doctrine\Specification\Unwritable;
+use Zenstruck\Collection\Spec;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class DoctrineSpec extends Spec
+{
+    public static function readonly(): Unwritable
+    {
+        return new Unwritable();
+    }
+
+    public static function delete(): Delete
+    {
+        return new Delete();
+    }
+
+    public static function cache(?int $lifetime = null, ?string $key = null): Cache
+    {
+        return new Cache($lifetime, $key);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function instanceOf(string $class): Instance
+    {
+        return new Instance($class);
+    }
+
+    public static function innerJoin(string $field, ?string $alias = null): Join
+    {
+        return Join::inner($field, $alias);
+    }
+
+    public static function leftJoin(string $field, ?string $alias = null): Join
+    {
+        return Join::left($field, $alias);
+    }
+
+    public static function antiJoin(string $field): AntiJoin
+    {
+        return new AntiJoin($field);
+    }
+}

--- a/src/Collection/Doctrine/ORM/EntityRepository.php
+++ b/src/Collection/Doctrine/ORM/EntityRepository.php
@@ -14,8 +14,10 @@ namespace Zenstruck\Collection\Doctrine\ORM;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\Proxy\DefaultProxyClassNameResolver;
 use Doctrine\ORM\QueryBuilder;
 use Zenstruck\Collection\Doctrine\ObjectRepository;
+use Zenstruck\Collection\Doctrine\ORM\Specification\QueryBuilderInterpreter;
 use Zenstruck\Collection\Exception\InvalidSpecification;
 
 /**
@@ -34,7 +36,7 @@ class EntityRepository implements ObjectRepository
     }
 
     /**
-     * @param mixed|Criteria|array<string,mixed>|(object&callable(QueryBuilder):void) $specification
+     * @param mixed|Criteria|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
      */
     public function find(mixed $specification): ?object
     {
@@ -53,6 +55,19 @@ class EntityRepository implements ObjectRepository
                 return $qb->getQuery()->getSingleResult();
             }
 
+            if (\is_object($specification)) {
+                try {
+                    return QueryBuilderInterpreter::interpret($specification, static::class, __FUNCTION__, $this->qb(), 'e') // @phpstan-ignore-line
+                        ->result()
+                        ->first()
+                    ;
+                } catch (InvalidSpecification $e) {
+                    if (!$this->em->getMetadataFactory()->hasMetadataFor(DefaultProxyClassNameResolver::getClass($specification))) {
+                        throw $e;
+                    }
+                }
+            }
+
             return $this->em()->find($this->class, $specification);
         } catch (NoResultException) {
             return null;
@@ -60,34 +75,23 @@ class EntityRepository implements ObjectRepository
     }
 
     /**
-     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder):void) $specification
+     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
      *
      * @return EntityResult<V>
      */
     public function query(mixed $specification): EntityResult
     {
-        $specification ??= [];
-        $qb = $this->qb();
+        return $this->resultFor($specification, __FUNCTION__);
+    }
 
-        if ($specification instanceof Criteria) {
-            return $qb->addCriteria($specification)->result();
-        }
-
-        if (\is_callable($specification) && \is_object($specification)) {
-            $specification($qb, 'e');
-
-            return $qb->result();
-        }
-
-        if (!\is_array($specification)) {
-            throw InvalidSpecification::build($specification, static::class, __FUNCTION__, 'Only array|Criteria|callable(QueryBuilder) supported.');
-        }
-
-        foreach ($specification as $field => $value) {
-            $qb->andWhere("e.{$field} = :{$field}")->setParameter($field, $value);
-        }
-
-        return $qb->result();
+    /**
+     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
+     *
+     * @return EntityResult<V>
+     */
+    public function filter(mixed $specification): EntityResult
+    {
+        return $this->resultFor($specification, __FUNCTION__);
     }
 
     public function count(): int
@@ -111,5 +115,40 @@ class EntityRepository implements ObjectRepository
     final protected function em(): EntityManagerInterface
     {
         return $this->em;
+    }
+
+    /**
+     * @return EntityResult<V>
+     */
+    private function resultFor(mixed $specification, string $method): EntityResult
+    {
+        $specification ??= [];
+        $qb = $this->qb();
+
+        if ($specification instanceof Criteria) {
+            return $qb->addCriteria($specification)->result();
+        }
+
+        if (\is_callable($specification) && \is_object($specification)) {
+            $specification($qb, 'e');
+
+            return $qb->result();
+        }
+
+        if (\is_object($specification)) {
+            return QueryBuilderInterpreter::interpret($specification, static::class, $method, $qb, 'e') // @phpstan-ignore-line
+                ->result()
+            ;
+        }
+
+        if (!\is_array($specification)) {
+            throw InvalidSpecification::build($specification, static::class, $method, 'Only array|Criteria|callable(QueryBuilder) supported.');
+        }
+
+        foreach ($specification as $field => $value) {
+            $qb->andWhere("e.{$field} = :{$field}")->setParameter($field, $value);
+        }
+
+        return $qb->result();
     }
 }

--- a/src/Collection/Doctrine/ORM/EntityRepositoryBridge.php
+++ b/src/Collection/Doctrine/ORM/EntityRepositoryBridge.php
@@ -25,7 +25,7 @@ trait EntityRepositoryBridge
     private EntityRepository $collectionRepo;
 
     /**
-     * @param mixed|Criteria|array<string,mixed>|(object&callable(QueryBuilder):void) $specification
+     * @param mixed|Criteria|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
      */
     public function find($specification, $lockMode = null, $lockVersion = null): ?object
     {
@@ -38,13 +38,23 @@ trait EntityRepositoryBridge
     }
 
     /**
-     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder):void) $specification
+     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
      *
      * @return EntityResult<V>
      */
     public function query(mixed $specification): EntityResult
     {
         return $this->collectionRepo()->query($specification);
+    }
+
+    /**
+     * @param Criteria|null|array<string,mixed>|(object&callable(QueryBuilder,string):void)|object $specification
+     *
+     * @return EntityResult<V>
+     */
+    public function filter(mixed $specification): EntityResult
+    {
+        return $this->query($specification);
     }
 
     public function getIterator(): \Traversable

--- a/src/Collection/Doctrine/ORM/Specification/AntiJoin.php
+++ b/src/Collection/Doctrine/ORM/Specification/AntiJoin.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\ORM\Specification;
+
+use Zenstruck\Collection\Specification\Field;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AntiJoin extends Field
+{
+}

--- a/src/Collection/Doctrine/ORM/Specification/Join.php
+++ b/src/Collection/Doctrine/ORM/Specification/Join.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\ORM\Specification;
+
+use Zenstruck\Collection\Specification\Field;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Join extends Field
+{
+    private const TYPE_INNER = 'inner';
+    private const TYPE_LEFT = 'left';
+
+    private string $alias;
+    private bool $eager = false;
+    private mixed $child = null;
+
+    /**
+     * @param self::TYPE_INNER|self::TYPE_LEFT $type
+     */
+    private function __construct(private string $type, string $field, ?string $alias = null)
+    {
+        parent::__construct($field);
+
+        $this->alias = $alias ?? $field;
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('%sJoin(%s)', \ucfirst($this->type()), $this->field());
+    }
+
+    public static function inner(string $field, ?string $alias = null): self
+    {
+        return new self(self::TYPE_INNER, $field, $alias);
+    }
+
+    public static function left(string $field, ?string $alias = null): self
+    {
+        return new self(self::TYPE_LEFT, $field, $alias);
+    }
+
+    public static function anti(string $field): AntiJoin
+    {
+        return new AntiJoin($field);
+    }
+
+    public function eager(): self
+    {
+        $this->eager = true;
+
+        return $this;
+    }
+
+    public function scope(mixed $specification): self
+    {
+        $this->child = $specification;
+
+        return $this;
+    }
+
+    public function alias(): string
+    {
+        return $this->alias;
+    }
+
+    /**
+     * @return self::TYPE_INNER|self::TYPE_LEFT
+     */
+    public function type(): string
+    {
+        return $this->type;
+    }
+
+    public function isEager(): bool
+    {
+        return $this->eager;
+    }
+
+    public function child(): mixed
+    {
+        return $this->child;
+    }
+}

--- a/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
+++ b/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\ORM\Specification;
+
+use Doctrine\ORM\Query\Expr\Comparison as DoctrineComparison;
+use Doctrine\ORM\Query\Expr\Composite as DoctrineComposite;
+use Doctrine\ORM\Query\Expr\Func;
+use Zenstruck\Collection\Doctrine\ORM\EntityResultQueryBuilder;
+use Zenstruck\Collection\Doctrine\Specification\Cache;
+use Zenstruck\Collection\Doctrine\Specification\Delete;
+use Zenstruck\Collection\Doctrine\Specification\Instance;
+use Zenstruck\Collection\Doctrine\Specification\Unwritable;
+use Zenstruck\Collection\Exception\InvalidSpecification;
+use Zenstruck\Collection\Specification\Callback;
+use Zenstruck\Collection\Specification\Comparison;
+use Zenstruck\Collection\Specification\Filter\Contains;
+use Zenstruck\Collection\Specification\Filter\EndsWith;
+use Zenstruck\Collection\Specification\Filter\EqualTo;
+use Zenstruck\Collection\Specification\Filter\GreaterThan;
+use Zenstruck\Collection\Specification\Filter\GreaterThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\In;
+use Zenstruck\Collection\Specification\Filter\IsNull;
+use Zenstruck\Collection\Specification\Filter\LessThan;
+use Zenstruck\Collection\Specification\Filter\LessThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\StartsWith;
+use Zenstruck\Collection\Specification\Logic\AndX;
+use Zenstruck\Collection\Specification\Logic\Composite;
+use Zenstruck\Collection\Specification\Logic\Not;
+use Zenstruck\Collection\Specification\Logic\OrX;
+use Zenstruck\Collection\Specification\Nested;
+use Zenstruck\Collection\Specification\OrderBy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class QueryBuilderInterpreter
+{
+    /**
+     * @param EntityResultQueryBuilder<object> $qb
+     * @param class-string                     $callingClass
+     */
+    private function __construct(
+        private EntityResultQueryBuilder $qb,
+        private string $alias,
+        private string $callingClass,
+        private string $callingMethod,
+    ) {
+    }
+
+    /**
+     * @param class-string                     $callingClass
+     * @param EntityResultQueryBuilder<object> $qb
+     *
+     * @return EntityResultQueryBuilder<object>
+     */
+    public static function interpret(
+        object $specification,
+        string $callingClass,
+        string $callingMethod,
+        EntityResultQueryBuilder $qb,
+        string $alias,
+    ): EntityResultQueryBuilder {
+        $self = new self($qb, $alias, $callingClass, $callingMethod);
+
+        if (self::isExpression($expression = $self->transform($specification))) {
+            $qb->andWhere($expression);
+        }
+
+        return $qb;
+    }
+
+    private function transform(object $specification): mixed
+    {
+        if ($specification instanceof Nested) {
+            return $this->transform($specification->specification());
+        }
+
+        return match ($specification::class) {
+            AndX::class => $this->composite($specification, 'andX'),
+            OrX::class => $this->composite($specification, 'orX'),
+            Not::class => $this->composite($specification, 'not'),
+
+            EqualTo::class => $this->qb->expr()->eq($this->prefix($specification->field()), $this->param($specification->value())),
+            LessThan::class => $this->qb->expr()->lt($this->prefix($specification->field()), $this->param($specification->value())),
+            LessThanOrEqualTo::class => $this->qb->expr()->lte($this->prefix($specification->field()), $this->param($specification->value())),
+            GreaterThan::class => $this->qb->expr()->gt($this->prefix($specification->field()), $this->param($specification->value())),
+            GreaterThanOrEqualTo::class => $this->qb->expr()->gte($this->prefix($specification->field()), $this->param($specification->value())),
+            In::class => $this->qb->expr()->in($this->prefix($specification->field()), $this->param($specification->value())),
+            IsNull::class => $this->qb->expr()->isNull($this->prefix($specification->field())),
+            Contains::class => $this->qb->expr()->like($this->prefix($specification->field()), $this->param('%'.self::normalizeLike($specification).'%')),
+            StartsWith::class => $this->qb->expr()->like($this->prefix($specification->field()), $this->param(self::normalizeLike($specification).'%')),
+            EndsWith::class => $this->qb->expr()->like($this->prefix($specification->field()), $this->param('%'.self::normalizeLike($specification))),
+
+            Callback::class => $specification->value()($this->qb, $this->alias), // @phpstan-ignore-line
+
+            OrderBy::class => $this->qb->addOrderBy($this->prefix($specification->field()), $specification->direction()),
+
+            Instance::class => $this->qb->expr()->isInstanceOf($this->alias, $this->param($specification->of())),
+            Delete::class => $this->qb->delete(),
+            Unwritable::class => $this->qb->readonly(),
+            Cache::class => $this->qb->cacheResult($specification->lifetime(), $specification->key()),
+            AntiJoin::class => $this->qb->leftJoin($this->prefix($specification->field()), $specification->field())->andWhere($this->qb->expr()->isNull($specification->field())),
+            Join::class => $this->interpretJoin($specification),
+
+            default => throw InvalidSpecification::build($specification, $this->callingClass, $this->callingMethod),
+        };
+    }
+
+    private function interpretJoin(Join $join): mixed
+    {
+        $this->addJoinToQueryBuilder($join);
+
+        if ($join->isEager()) {
+            $this->qb->addSelect($join->alias());
+        }
+
+        if (null === $join->child()) {
+            return null;
+        }
+
+        $interpreter = clone $this;
+        $interpreter->alias = $join->alias();
+
+        return $interpreter->transform($join->child());
+    }
+
+    private function addJoinToQueryBuilder(Join $join): void
+    {
+        $field = $this->prefix($join->field());
+
+        foreach ($this->qb->getDQLParts()['join'] as $entry) {
+            foreach ($entry as $item) {
+                if ($field === $item->getJoin()) {
+                    // join already added
+                    return;
+                }
+            }
+        }
+
+        $this->qb->{$join->type().'Join'}($field, $join->alias());
+    }
+
+    private function composite(Composite $specification, string $method): DoctrineComposite|Func|null
+    {
+        if (!$expressions = $this->filter($specification)) {
+            return null;
+        }
+
+        return $this->qb->expr()->{$method}(...$expressions);
+    }
+
+    /**
+     * @return list<Func|DoctrineComparison|DoctrineComposite>
+     */
+    private function filter(Composite $specification): array
+    {
+        return \array_values(
+            \array_filter(
+                \array_map(
+                    fn(object $child) => $this->transform($child),
+                    $specification->children(),
+                ),
+                static fn(mixed $child) => self::isExpression($child),
+            ),
+        );
+    }
+
+    private static function normalizeLike(Comparison $comparison): string
+    {
+        return \str_replace(['%', '*'], ['%%', '%'], \trim($comparison->value(), '*')); // todo make wildcard char configurable?
+    }
+
+    private function param(mixed $value): string
+    {
+        $param = \sprintf('param_%d', \count($this->qb->getParameters()) + 1);
+
+        $this->qb->setParameter($param, $value);
+
+        return ":{$param}";
+    }
+
+    private static function isExpression(mixed $what): bool
+    {
+        return \is_string($what) || $what instanceof Func || $what instanceof DoctrineComparison || $what instanceof DoctrineComposite;
+    }
+
+    private function prefix(string $field): string
+    {
+        return "{$this->alias}.{$field}";
+    }
+}

--- a/src/Collection/Doctrine/ObjectRepository.php
+++ b/src/Collection/Doctrine/ObjectRepository.php
@@ -13,14 +13,16 @@ namespace Zenstruck\Collection\Doctrine;
 
 use Doctrine\Common\Collections\Criteria;
 use Zenstruck\Collection\Exception\InvalidSpecification;
+use Zenstruck\Collection\Matchable;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @template V of object
+ * @extends Matchable<int,V>
  * @extends \IteratorAggregate<int,V>
  */
-interface ObjectRepository extends \Countable, \IteratorAggregate
+interface ObjectRepository extends Matchable, \Countable, \IteratorAggregate
 {
     public const ALL = null;
 
@@ -32,11 +34,18 @@ interface ObjectRepository extends \Countable, \IteratorAggregate
     public function find(mixed $specification): ?object;
 
     /**
-     * @param mixed|self::ALL|array|Criteria $specification
+     * @param mixed|self::ALL|array|Criteria|object $specification
      *
      * @return Result<V>
      *
      * @throws InvalidSpecification if the specification is not supported
      */
     public function query(mixed $specification): Result;
+
+    /**
+     * @param mixed|self::ALL|array|Criteria|object $specification
+     *
+     * @return Result<V>
+     */
+    public function filter(mixed $specification): Result;
 }

--- a/src/Collection/Doctrine/Result.php
+++ b/src/Collection/Doctrine/Result.php
@@ -11,7 +11,9 @@
 
 namespace Zenstruck\Collection\Doctrine;
 
+use Doctrine\Common\Collections\Criteria;
 use Zenstruck\Collection;
+use Zenstruck\Collection\Matchable;
 
 /**
  * Represents a Doctrine result set.
@@ -21,8 +23,9 @@ use Zenstruck\Collection;
  * @immutable
  * @template V
  * @extends Collection<int,V>
+ * @extends Matchable<int,V>
  */
-interface Result extends Collection
+interface Result extends Collection, Matchable
 {
     /**
      * "Batch iterate" the result set, clearing the
@@ -39,6 +42,16 @@ interface Result extends Collection
      * @return \Traversable<V>
      */
     public function batchProcess(int $chunkSize = 100): \Traversable;
+
+    /**
+     * @param mixed|Criteria|callable(V,int):bool $specification
+     */
+    public function find(mixed $specification, mixed $default = null): mixed;
+
+    /**
+     * @param mixed|Criteria|callable(V,int):bool $specification
+     */
+    public function filter(mixed $specification): Collection;
 
     /**
      * If results are managed objects, detach them from the

--- a/src/Collection/Doctrine/Specification/Cache.php
+++ b/src/Collection/Doctrine/Specification/Cache.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Cache implements \Stringable
+{
+    public function __construct(private ?int $lifetime = null, private ?string $key = null)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('Cache(lifetime: %s, key: %s)', $this->lifetime ?? '<null>', $this->key ?? '<null>');
+    }
+
+    public function lifetime(): ?int
+    {
+        return $this->lifetime;
+    }
+
+    public function key(): ?string
+    {
+        return $this->key;
+    }
+}

--- a/src/Collection/Doctrine/Specification/CriteriaInterpreter.php
+++ b/src/Collection/Doctrine/Specification/CriteriaInterpreter.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\Specification;
+
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Expression;
+use Zenstruck\Collection\Exception\InvalidSpecification;
+use Zenstruck\Collection\Specification\Callback;
+use Zenstruck\Collection\Specification\Filter\Contains;
+use Zenstruck\Collection\Specification\Filter\EndsWith;
+use Zenstruck\Collection\Specification\Filter\EqualTo;
+use Zenstruck\Collection\Specification\Filter\GreaterThan;
+use Zenstruck\Collection\Specification\Filter\GreaterThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\In;
+use Zenstruck\Collection\Specification\Filter\IsNull;
+use Zenstruck\Collection\Specification\Filter\LessThan;
+use Zenstruck\Collection\Specification\Filter\LessThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\StartsWith;
+use Zenstruck\Collection\Specification\Logic\AndX;
+use Zenstruck\Collection\Specification\Logic\Composite;
+use Zenstruck\Collection\Specification\Logic\Not;
+use Zenstruck\Collection\Specification\Logic\OrX;
+use Zenstruck\Collection\Specification\Nested;
+use Zenstruck\Collection\Specification\OrderBy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class CriteriaInterpreter
+{
+    /** @var array<string,string> */
+    private array $orderBy = [];
+
+    /**
+     * @param class-string $class
+     */
+    private function __construct(private Criteria $criteria, private string $class, private string $method)
+    {
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public static function interpret(object $specification, string $class, string $method, ?Criteria $criteria = null): Criteria
+    {
+        $self = new self($criteria ?? new Criteria(), $class, $method);
+
+        if ($expression = $self->transform($specification)) {
+            $self->criteria->andWhere($expression);
+        }
+
+        if ($self->orderBy) {
+            $self->criteria->orderBy($self->orderBy);
+        }
+
+        return $self->criteria;
+    }
+
+    private function transform(object $specification): ?Expression
+    {
+        if ($specification instanceof Nested) {
+            return $this->transform($specification->specification());
+        }
+
+        if ($specification instanceof OrderBy) {
+            $this->orderBy[$specification->field()] = $specification->direction();
+
+            return null;
+        }
+
+        return match ($specification::class) {
+            AndX::class => $this->composite($specification, 'andX'),
+            OrX::class => $this->composite($specification, 'orX'),
+            Not::class => $this->composite($specification, 'not'),
+
+            Contains::class => Criteria::expr()->contains($specification->field(), $specification->value()),
+            EndsWith::class => Criteria::expr()->endsWith($specification->field(), $specification->value()),
+            EqualTo::class => Criteria::expr()->eq($specification->field(), $specification->value()),
+            GreaterThan::class => Criteria::expr()->gt($specification->field(), $specification->value()),
+            GreaterThanOrEqualTo::class => Criteria::expr()->gte($specification->field(), $specification->value()),
+            In::class => Criteria::expr()->in($specification->field(), $specification->value()),
+            IsNull::class => Criteria::expr()->isNull($specification->field()),
+            LessThan::class => Criteria::expr()->lt($specification->field(), $specification->value()),
+            LessThanOrEqualTo::class => Criteria::expr()->lte($specification->field(), $specification->value()),
+            StartsWith::class => Criteria::expr()->startsWith($specification->field(), $specification->value()),
+
+            Callback::class => $specification->value()($this->criteria),
+
+            default => throw InvalidSpecification::build($specification, $this->class, $this->method),
+        };
+    }
+
+    private function composite(Composite $specification, string $method): ?Expression
+    {
+        if (!$expressions = $this->filter($specification)) {
+            return null;
+        }
+
+        return Criteria::expr()->{$method}(...$expressions);
+    }
+
+    /**
+     * @return Expression[]
+     */
+    private function filter(Composite $specification): array
+    {
+        return \array_values(
+            \array_filter(
+                \array_map(
+                    fn(object $child) => $this->transform($child),
+                    $specification->children(),
+                ),
+                static fn(mixed $child) => $child instanceof Expression,
+            ),
+        );
+    }
+}

--- a/src/Collection/Doctrine/Specification/Delete.php
+++ b/src/Collection/Doctrine/Specification/Delete.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Delete implements \Stringable
+{
+    public function __toString(): string
+    {
+        return 'Delete';
+    }
+}

--- a/src/Collection/Doctrine/Specification/Instance.php
+++ b/src/Collection/Doctrine/Specification/Instance.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Instance implements \Stringable
+{
+    /**
+     * @param class-string $of
+     */
+    public function __construct(private string $of)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('Instance(%s)', $this->of);
+    }
+
+    public function of(): string
+    {
+        return $this->of;
+    }
+}

--- a/src/Collection/Doctrine/Specification/Unwritable.php
+++ b/src/Collection/Doctrine/Specification/Unwritable.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Doctrine\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Unwritable implements \Stringable
+{
+    public function __toString(): string
+    {
+        return 'Readonly';
+    }
+}

--- a/src/Collection/Exception/InvalidSpecification.php
+++ b/src/Collection/Exception/InvalidSpecification.php
@@ -11,6 +11,8 @@
 
 namespace Zenstruck\Collection\Exception;
 
+use Zenstruck\Collection\Specification\Util;
+
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -25,11 +27,9 @@ final class InvalidSpecification extends \InvalidArgumentException
             $what = \sprintf('%s (%s)', $what, \get_debug_type($what));
         }
 
-        if ($what instanceof \Stringable) {
-            $what = (string) $what;
+        if (\is_object($what) && !\is_callable($what)) {
+            $what = Util::stringify($what);
         }
-
-        // todo: stringify closures
 
         if (!\is_scalar($what)) {
             $what = \get_debug_type($what);

--- a/src/Collection/Matchable.php
+++ b/src/Collection/Matchable.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection;
+
+use Zenstruck\Collection;
+use Zenstruck\Collection\Exception\InvalidSpecification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template K
+ * @template V
+ */
+interface Matchable
+{
+    /**
+     * @return V|null
+     *
+     * @throws InvalidSpecification if $specification is not valid
+     */
+    public function find(object $specification): mixed;
+
+    /**
+     * @return Collection<K,V>
+     */
+    public function filter(mixed $specification): Collection;
+}

--- a/src/Collection/Spec.php
+++ b/src/Collection/Spec.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection;
+
+use Zenstruck\Collection\Specification\Callback;
+use Zenstruck\Collection\Specification\Filter\Contains;
+use Zenstruck\Collection\Specification\Filter\EndsWith;
+use Zenstruck\Collection\Specification\Filter\EqualTo;
+use Zenstruck\Collection\Specification\Filter\GreaterThan;
+use Zenstruck\Collection\Specification\Filter\GreaterThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\In;
+use Zenstruck\Collection\Specification\Filter\IsNull;
+use Zenstruck\Collection\Specification\Filter\LessThan;
+use Zenstruck\Collection\Specification\Filter\LessThanOrEqualTo;
+use Zenstruck\Collection\Specification\Filter\StartsWith;
+use Zenstruck\Collection\Specification\Logic\AndX;
+use Zenstruck\Collection\Specification\Logic\Not;
+use Zenstruck\Collection\Specification\Logic\OrX;
+use Zenstruck\Collection\Specification\OrderBy;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+class Spec
+{
+    private function __construct()
+    {
+    }
+
+    final public static function andX(mixed ...$children): AndX
+    {
+        return new AndX(...$children);
+    }
+
+    final public static function orX(mixed ...$children): OrX
+    {
+        return new OrX(...$children);
+    }
+
+    final public static function not(mixed $restriction): Not
+    {
+        return new Not($restriction);
+    }
+
+    final public static function eq(string $field, mixed $value): EqualTo
+    {
+        return new EqualTo($field, $value);
+    }
+
+    final public static function contains(string $field, string $value): Contains
+    {
+        return new Contains($field, $value);
+    }
+
+    final public static function startsWith(string $field, string $value): StartsWith
+    {
+        return new StartsWith($field, $value);
+    }
+
+    final public static function endsWith(string $field, ?string $value): EndsWith
+    {
+        return new EndsWith($field, $value);
+    }
+
+    final public static function isNull(string $field): IsNull
+    {
+        return new IsNull($field);
+    }
+
+    /**
+     * @param mixed[] $values
+     */
+    final public static function in(string $field, array $values): In
+    {
+        return new In($field, $values);
+    }
+
+    final public static function lt(string $field, mixed $value): LessThan
+    {
+        return new LessThan($field, $value);
+    }
+
+    final public static function lte(string $field, mixed $value): LessThanOrEqualTo
+    {
+        return new LessThanOrEqualTo($field, $value);
+    }
+
+    final public static function gt(string $field, mixed $value): GreaterThan
+    {
+        return new GreaterThan($field, $value);
+    }
+
+    final public static function gte(string $field, mixed $value): GreaterThanOrEqualTo
+    {
+        return new GreaterThanOrEqualTo($field, $value);
+    }
+
+    /**
+     * @template C
+     *
+     * @param callable(C):mixed $value
+     *
+     * @return Callback<C>
+     */
+    final public static function callback(callable $value): Callback
+    {
+        return new Callback($value);
+    }
+
+    final public static function sortAsc(string $field): OrderBy
+    {
+        return OrderBy::asc($field);
+    }
+
+    final public static function sortDesc(string $field): OrderBy
+    {
+        return OrderBy::desc($field);
+    }
+}

--- a/src/Collection/Specification/Callback.php
+++ b/src/Collection/Specification/Callback.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @template C
+ */
+final class Callback
+{
+    /** @var callable(C):mixed */
+    private $value;
+
+    /**
+     * @param callable(C):mixed $value
+     */
+    public function __construct(callable $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return callable(C):mixed
+     */
+    public function value(): callable
+    {
+        return $this->value;
+    }
+}

--- a/src/Collection/Specification/Comparison.php
+++ b/src/Collection/Specification/Comparison.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class Comparison extends Field
+{
+    public function __construct(string $field, private mixed $value)
+    {
+        parent::__construct($field);
+    }
+
+    final public function __toString(): string
+    {
+        $value = $this->value;
+
+        if (\is_string($value)) {
+            $value = "'{$value}'";
+        }
+
+        return \sprintf('Compare(%s %s %s)',
+            $this->field(),
+            (new \ReflectionClass($this))->getShortName(),
+            \is_scalar($value) ? $value : \get_debug_type($value),
+        );
+    }
+
+    final public function value(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/Collection/Specification/Field.php
+++ b/src/Collection/Specification/Field.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class Field implements \Stringable
+{
+    public function __construct(private string $field)
+    {
+    }
+
+    public function __toString(): string
+    {
+        return \sprintf('%s(%s)', (new \ReflectionClass($this))->getShortName(), $this->field());
+    }
+
+    final public function field(): string
+    {
+        return $this->field;
+    }
+}

--- a/src/Collection/Specification/Filter/Contains.php
+++ b/src/Collection/Specification/Filter/Contains.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Contains extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/EndsWith.php
+++ b/src/Collection/Specification/Filter/EndsWith.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class EndsWith extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/EqualTo.php
+++ b/src/Collection/Specification/Filter/EqualTo.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class EqualTo extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/GreaterThan.php
+++ b/src/Collection/Specification/Filter/GreaterThan.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class GreaterThan extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/GreaterThanOrEqualTo.php
+++ b/src/Collection/Specification/Filter/GreaterThanOrEqualTo.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class GreaterThanOrEqualTo extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/In.php
+++ b/src/Collection/Specification/Filter/In.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @method mixed[] value()
+ */
+final class In extends Comparison
+{
+    /**
+     * @param mixed[] $value
+     */
+    public function __construct(string $field, array $value)
+    {
+        parent::__construct($field, $value);
+    }
+}

--- a/src/Collection/Specification/Filter/IsNull.php
+++ b/src/Collection/Specification/Filter/IsNull.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Field;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class IsNull extends Field
+{
+}

--- a/src/Collection/Specification/Filter/LessThan.php
+++ b/src/Collection/Specification/Filter/LessThan.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LessThan extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/LessThanOrEqualTo.php
+++ b/src/Collection/Specification/Filter/LessThanOrEqualTo.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class LessThanOrEqualTo extends Comparison
+{
+}

--- a/src/Collection/Specification/Filter/StartsWith.php
+++ b/src/Collection/Specification/Filter/StartsWith.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Filter;
+
+use Zenstruck\Collection\Specification\Comparison;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class StartsWith extends Comparison
+{
+}

--- a/src/Collection/Specification/Logic/AndX.php
+++ b/src/Collection/Specification/Logic/AndX.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Logic;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class AndX extends Composite
+{
+}

--- a/src/Collection/Specification/Logic/Composite.php
+++ b/src/Collection/Specification/Logic/Composite.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Logic;
+
+use Zenstruck\Collection\Specification\Util;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+abstract class Composite implements \Stringable
+{
+    /** @var mixed[] */
+    private array $children;
+
+    public function __construct(mixed ...$children)
+    {
+        $this->children = $children;
+    }
+
+    final public function __toString(): string
+    {
+        $children = \array_filter(\array_map([Util::class, 'stringify'], $this->children()));
+
+        return \sprintf('%s(%s)', (new \ReflectionClass($this))->getShortName(), \implode(', ', $children));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    final public function children(): array
+    {
+        return $this->children;
+    }
+}

--- a/src/Collection/Specification/Logic/Not.php
+++ b/src/Collection/Specification/Logic/Not.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Logic;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class Not extends Composite
+{
+    public function __construct(mixed $restriction)
+    {
+        parent::__construct($restriction);
+    }
+}

--- a/src/Collection/Specification/Logic/OrX.php
+++ b/src/Collection/Specification/Logic/OrX.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification\Logic;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class OrX extends Composite
+{
+}

--- a/src/Collection/Specification/Nested.php
+++ b/src/Collection/Specification/Nested.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface Nested
+{
+    public function specification(): mixed;
+}

--- a/src/Collection/Specification/OrderBy.php
+++ b/src/Collection/Specification/OrderBy.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class OrderBy extends Field
+{
+    private string $direction;
+
+    private function __construct(string $field, string $direction)
+    {
+        parent::__construct($field);
+
+        $this->direction = \mb_strtoupper($direction);
+    }
+
+    public static function asc(string $field): self
+    {
+        return new self($field, 'ASC');
+    }
+
+    public static function desc(string $field): self
+    {
+        return new self($field, 'DESC');
+    }
+
+    public function direction(): string
+    {
+        return $this->direction;
+    }
+}

--- a/src/Collection/Specification/Util.php
+++ b/src/Collection/Specification/Util.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Specification;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class Util
+{
+    public static function stringify(mixed $specification): string
+    {
+        if ($specification instanceof \Stringable) {
+            return $specification;
+        }
+
+        if ($specification instanceof Nested) {
+            return \sprintf('%s(%s)', $specification::class, self::stringify($specification->specification()));
+        }
+
+        return \get_debug_type($specification);
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,7 @@ use Zenstruck\Collection\LazyCollection;
  * @param null|iterable<K,V>|callable():iterable<K,V> $source
  *
  * @return Collection<K,V>
- * @phpstan-return ($source is null ? Collection<never,never> : Collection<K,V>)
+ * @phpstan-return ($source is null ? Collection<never,never> : ($source is array ? ArrayCollection<K&array-key,V> : ($source is DoctrineCollection<K&array-key,V> ? DoctrineBridgeCollection<K&array-key,V> : Collection<K,V>)))
  */
 function collect(iterable|callable|null $source = null): Collection
 {

--- a/tests/CollectionTests.php
+++ b/tests/CollectionTests.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Collection\Tests;
 
 use Zenstruck\Collection;
+use Zenstruck\Collection\Exception\InvalidSpecification;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -177,6 +178,30 @@ trait CollectionTests
         $this->assertNull($this->createWithItems(0)->reduce($function));
         $this->assertSame(10, $this->createWithItems(5)->reduce($function));
         $this->assertSame(15, $this->createWithItems(5)->reduce($function, 5));
+    }
+
+    /**
+     * @test
+     */
+    public function invalid_filter_specification(): void
+    {
+        $collection = $this->createWithItems(1);
+
+        $this->expectException(InvalidSpecification::class);
+
+        $collection->filter(new \stdClass());
+    }
+
+    /**
+     * @test
+     */
+    public function invalid_find_specification(): void
+    {
+        $collection = $this->createWithItems(1);
+
+        $this->expectException(InvalidSpecification::class);
+
+        $collection->find(new \stdClass());
     }
 
     abstract protected function createWithItems(int $count): Collection;

--- a/tests/Doctrine/DoctrineBridgeCollectionTest.php
+++ b/tests/Doctrine/DoctrineBridgeCollectionTest.php
@@ -19,6 +19,7 @@ use Zenstruck\Collection\LazyCollection;
 use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Relation;
+use Zenstruck\Collection\Tests\MatchableObjectTests;
 
 use function Zenstruck\collect;
 
@@ -27,7 +28,7 @@ use function Zenstruck\collect;
  */
 final class DoctrineBridgeCollectionTest extends TestCase
 {
-    use CollectionTests, HasDatabase;
+    use CollectionTests, HasDatabase, MatchableObjectTests;
 
     private DoctrineBridgeCollection $collection;
 
@@ -81,6 +82,32 @@ final class DoctrineBridgeCollectionTest extends TestCase
         }
 
         $this->assertFalse($persistentCollection->isInitialized());
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_criteria_as_filter_specification(): void
+    {
+        $collection = $this->createWithItems(10);
+        $criteria = Criteria::create()->where(Criteria::expr()->lt('id', 5))
+            ->orderBy(['id' => Criteria::DESC])
+        ;
+
+        $this->assertSame('value 4', $collection->filter($criteria)->first()->value);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_criteria_as_find_specification(): void
+    {
+        $collection = $this->createWithItems(10);
+        $criteria = Criteria::create()->where(Criteria::expr()->lt('id', 5))
+            ->orderBy(['id' => Criteria::DESC])
+        ;
+
+        $this->assertSame('value 4', $collection->find($criteria)->value);
     }
 
     /**

--- a/tests/Doctrine/ORM/Result/ObjectResultTest.php
+++ b/tests/Doctrine/ORM/Result/ObjectResultTest.php
@@ -11,17 +11,21 @@
 
 namespace Zenstruck\Collection\Tests\Doctrine\ORM\Result;
 
+use Doctrine\Common\Collections\Criteria;
 use Zenstruck\Collection\Doctrine\Batch\CountableBatchIterator;
 use Zenstruck\Collection\Doctrine\Batch\CountableBatchProcessor;
 use Zenstruck\Collection\Doctrine\ORM\EntityResult;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\ORM\EntityResultTest;
+use Zenstruck\Collection\Tests\MatchableObjectTests;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 class ObjectResultTest extends EntityResultTest
 {
+    use MatchableObjectTests;
+
     /**
      * @test
      */
@@ -108,6 +112,32 @@ class ObjectResultTest extends EntityResultTest
         $entity = $this->createWithItems(1)->readonly()->first();
 
         $this->assertFalse($this->em->contains($entity));
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_criteria_as_filter_specification(): void
+    {
+        $collection = $this->createWithItems(10);
+        $criteria = Criteria::create()->where(Criteria::expr()->lt('id', 5))
+            ->orderBy(['id' => Criteria::DESC])
+        ;
+
+        $this->assertEquals($this->expectedValueAt(4), $collection->filter($criteria)->first());
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_criteria_as_find_specification(): void
+    {
+        $collection = $this->createWithItems(10);
+        $criteria = Criteria::create()->where(Criteria::expr()->lt('id', 5))
+            ->orderBy(['id' => Criteria::DESC])
+        ;
+
+        $this->assertEquals($this->expectedValueAt(4), $collection->find($criteria));
     }
 
     protected function expectedValueAt(int $position): object

--- a/tests/MatchableObjectTests.php
+++ b/tests/MatchableObjectTests.php
@@ -1,0 +1,319 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests;
+
+use Zenstruck\Collection\Matchable;
+use Zenstruck\Collection\Spec;
+use Zenstruck\Collection\Specification\Nested;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+trait MatchableObjectTests
+{
+    /**
+     * @test
+     */
+    public function can_use_specification_object_for_filter(): void
+    {
+        $collection = $this->createWithItems(10);
+        $spec = Spec::andX(
+            Spec::lt('id', 5),
+            Spec::sortDesc('id'),
+        );
+
+        $this->assertEquals($this->expectedValueAt(4), $collection->filter($spec)->first());
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_specification_object_for_find(): void
+    {
+        $collection = $this->createWithItems(10);
+        $spec = Spec::andX(
+            Spec::lt('id', 5),
+            Spec::sortDesc('id'),
+        );
+
+        $this->assertEquals($this->expectedValueAt(4), $collection->find($spec));
+    }
+
+    /**
+     * @test
+     */
+    public function filter_and_x_composite(): void
+    {
+        $repo = $this->createWithItems(3);
+
+        $objects = $repo->filter(
+            Spec::andX(
+                Spec::gt('id', 1),
+                Spec::lt('id', 3)
+            )
+        );
+
+        $this->assertCount(1, $objects);
+        $this->assertSame('value 2', $objects->first()->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_or_x_composite(): void
+    {
+        $objects = $this->createWithItems(3)->filter(
+            Spec::orX(
+                Spec::lt('id', 2),
+                Spec::gt('id', 2)
+            )
+        )->eager()->values();
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 1', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 3', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_contains_exact(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::contains('value', 'value 2'))->eager()->values();
+
+        $this->assertCount(1, $objects);
+        $this->assertSame('value 2', \iterator_to_array($objects)[0]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_contains_partial(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::contains('value', 'lue'))->eager()->values();
+
+        $this->assertCount(3, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_contains_no_match(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::contains('value', 'invalid'));
+
+        $this->assertCount(0, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_starts_with(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::startsWith('value', 'va'))->eager()->values();
+
+        $this->assertCount(3, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_starts_with_no_match(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::startsWith('value', 'invalid'));
+
+        $this->assertCount(0, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_ends_with(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::endsWith('value', '2'))->eager()->values();
+
+        $this->assertCount(1, $objects);
+        $this->assertSame('value 2', \iterator_to_array($objects)[0]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_ends_with_no_match(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::endsWith('value', 'invalid'));
+
+        $this->assertCount(0, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_not_contains(): void
+    {
+        $objects = $this->createWithItems(3)
+            ->filter(Spec::not(Spec::contains('value', 'value 2')))
+            ->eager()
+            ->values()
+        ;
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 1', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 3', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_is_null(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::isNull('value'));
+
+        $this->assertCount(0, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_is_not_null(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::not(Spec::isNull('value')));
+
+        $this->assertCount(3, $objects);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_in_string(): void
+    {
+        $objects = $this->createWithItems(3)
+            ->filter(Spec::in('value', ['value 1', 'value 3']))
+            ->eager()
+            ->values()
+        ;
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 1', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 3', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_less_than(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::lt('id', 3))->eager()->values();
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 1', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 2', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_less_than_equal(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::lte('id', 2))->eager()->values();
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 1', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 2', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_greater_than(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::gt('id', 1))->eager()->values();
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 2', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 3', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_greater_than_equal(): void
+    {
+        $objects = $this->createWithItems(3)->filter(Spec::gte('id', 2))->eager()->values();
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 2', \iterator_to_array($objects)[0]->value);
+        $this->assertSame('value 3', \iterator_to_array($objects)[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_sort_desc(): void
+    {
+        $objects = \iterator_to_array(
+            $this->createWithItems(3)->filter(Spec::sortDesc('value'))->eager()->values()
+        );
+
+        $this->assertSame('value 3', $objects[0]->value);
+        $this->assertSame('value 2', $objects[1]->value);
+        $this->assertSame('value 1', $objects[2]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_sort_asc(): void
+    {
+        $objects = \iterator_to_array(
+            $this->createWithItems(3)->filter(Spec::sortAsc('value'))->eager()->values()
+        );
+
+        $this->assertSame('value 1', $objects[0]->value);
+        $this->assertSame('value 2', $objects[1]->value);
+        $this->assertSame('value 3', $objects[2]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function filter_composite_order_by(): void
+    {
+        $objects = \iterator_to_array($this->createWithItems(3)->filter(
+            Spec::andX(
+                Spec::gt('id', 1),
+                Spec::sortDesc('id')
+            )
+        )->eager()->values());
+
+        $this->assertCount(2, $objects);
+        $this->assertSame('value 3', $objects[0]->value);
+        $this->assertSame('value 2', $objects[1]->value);
+    }
+
+    /**
+     * @test
+     */
+    public function can_use_nested_specification(): void
+    {
+        $object = $this->createWithItems(3)->find(new class() implements Nested {
+            public function specification(): mixed
+            {
+                return Spec::eq('value', 'value 2');
+            }
+        });
+
+        $this->assertSame('value 2', $object->value);
+    }
+
+    abstract protected function createWithItems(int $count): Matchable;
+}


### PR DESCRIPTION
- [x] `Collection::find()`/`filter()` accept mixed `$specification`
- [x] `DoctrineBridgeCollection::find()`/`filter()` can accept `Criteria` instance as `$specification`
- [x] `DoctrineBridgeCollection::find()`/`filter()` can accept "specification objects"
- [x] `EntityResult::find()`/`filter()` can accept `Criteria` instance as `$specification`
- [x] `EntityResult::find()`/`filter()` can accept "specification objects"
- [x] `Matchable` interface with `find`/`filter` methods. Implemented by `Collection` and `ObjectRepository`.
- [x] doctrine-specific specification system 

Fixes #29 