### PR TITLE
[BC BREAK] PHPStan improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/orm": "^2.15|^3.0",
         "pagerfanta/pagerfanta": "^1.0|^2.0|^3.0|^4.0",
-        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan": "^2.1.17",
         "phpunit/phpunit": "^9.6.21",
         "symfony/expression-language": "^6.4|^7.0",
         "symfony/framework-bundle": "^6.4|^7.0",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -19,8 +19,8 @@ use Zenstruck\Collection\Pages;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
+ * @template K = array-key
  * @extends \IteratorAggregate<K,V>
  *
  * @method static dump()
@@ -31,7 +31,7 @@ interface Collection extends \IteratorAggregate, \Countable
     /**
      * @param mixed|callable(V,K):bool $specification
      *
-     * @return self<K,V>
+     * @return self<V,K>
      *
      * @throws InvalidSpecification if $specification is not valid
      */
@@ -42,7 +42,7 @@ interface Collection extends \IteratorAggregate, \Countable
      *
      * @param callable(V,K):T $function
      *
-     * @return self<K,T>
+     * @return self<T,K>
      */
     public function map(callable $function): self;
 
@@ -51,12 +51,12 @@ interface Collection extends \IteratorAggregate, \Countable
      *
      * @param callable(V,K):T $function
      *
-     * @return self<T,V>
+     * @return self<V,T>
      */
     public function keyBy(callable $function): self;
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function take(int $limit, int $offset = 0): self;
 
@@ -94,7 +94,7 @@ interface Collection extends \IteratorAggregate, \Countable
     public function isEmpty(): bool;
 
     /**
-     * @return ArrayCollection<K&array-key,V>
+     * @return ArrayCollection<V,K&array-key>
      */
     public function eager(): ArrayCollection;
 
@@ -102,14 +102,14 @@ interface Collection extends \IteratorAggregate, \Countable
      * @param positive-int $page
      * @param positive-int $limit
      *
-     * @return Page<K,V>
+     * @return Page<V,K>
      */
     public function paginate(int $page = 1, int $limit = Page::DEFAULT_LIMIT): Page;
 
     /**
      * @param positive-int $limit
      *
-     * @return Pages<K,V>
+     * @return Pages<V,K>
      */
     public function pages(int $limit = Page::DEFAULT_LIMIT): Pages;
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -99,11 +99,16 @@ interface Collection extends \IteratorAggregate, \Countable
     public function eager(): ArrayCollection;
 
     /**
+     * @param positive-int $page
+     * @param positive-int $limit
+     *
      * @return Page<K,V>
      */
     public function paginate(int $page = 1, int $limit = Page::DEFAULT_LIMIT): Page;
 
     /**
+     * @param positive-int $limit
+     *
      * @return Pages<K,V>
      */
     public function pages(int $limit = Page::DEFAULT_LIMIT): Pages;

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -19,13 +19,13 @@ use Zenstruck\Collection\Exception\InvalidSpecification;
  *
  * @immutable
  *
- * @template K of array-key
  * @template V
- * @implements Collection<K,V>
+ * @template K of array-key = array-key
+ * @implements Collection<V,K>
  */
 final class ArrayCollection implements Collection
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection;
 
     /** @var array<K,V> */
@@ -50,7 +50,7 @@ final class ArrayCollection implements Collection
     /**
      * @param null|iterable<K,V>|callable():iterable<K,V> $source
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public static function for(iterable|callable|null $source = null): self
     {
@@ -58,7 +58,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<array-key,mixed>
+     * @return self<mixed>
      */
     public static function wrap(mixed $value): self
     {
@@ -76,7 +76,7 @@ final class ArrayCollection implements Collection
      *
      * @param non-empty-string $separator
      *
-     * @return self<int,string>
+     * @return self<string,int>
      */
     public static function explode(string $separator, string $string, ?int $limit = null): self
     {
@@ -93,7 +93,7 @@ final class ArrayCollection implements Collection
      * @param T $start
      * @param T $end
      *
-     * @return self<int,T>
+     * @return self<T,int>
      */
     public static function range(int|string|float $start, int|string|float $end, int|float $step = 1): self
     {
@@ -107,7 +107,7 @@ final class ArrayCollection implements Collection
      *
      * @param T $value
      *
-     * @return self<int,T>
+     * @return self<T,int>
      */
     public static function fill(int $start, int $count, mixed $value): self
     {
@@ -120,7 +120,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function take(int $limit, int $offset = 0): self
     {
@@ -136,7 +136,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<int,K>
+     * @return self<K,int>
      */
     public function keys(): self
     {
@@ -144,7 +144,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<int,V>
+     * @return self<V,int>
      */
     public function values(): self
     {
@@ -152,7 +152,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function reverse(): self
     {
@@ -160,7 +160,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function slice(int $offset, ?int $length = null): self
     {
@@ -170,7 +170,7 @@ final class ArrayCollection implements Collection
     /**
      * @param iterable<K,V> ...$with
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function merge(iterable ...$with): self
     {
@@ -182,7 +182,7 @@ final class ArrayCollection implements Collection
     /**
      * @param null|callable(V,K):bool $specification
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function filter(mixed $specification = null): self
     {
@@ -198,7 +198,7 @@ final class ArrayCollection implements Collection
      *
      * @param callable(V,K):T $function
      *
-     * @return self<array-key,V>
+     * @return self<V>
      */
     public function keyBy(callable $function): self
     {
@@ -218,7 +218,7 @@ final class ArrayCollection implements Collection
      *
      * @param callable(V,K):T $function
      *
-     * @return self<K,T>
+     * @return self<T,K>
      */
     public function map(callable $function): self
     {
@@ -228,7 +228,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sort(int|callable $flags = \SORT_REGULAR): self
     {
@@ -239,7 +239,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sortDesc(int|callable $flags = \SORT_REGULAR): self
     {
@@ -249,7 +249,7 @@ final class ArrayCollection implements Collection
     /**
      * @param callable(V,K):mixed $function
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sortBy(callable $function, int $flags = \SORT_REGULAR): self
     {
@@ -272,7 +272,7 @@ final class ArrayCollection implements Collection
     /**
      * @param callable(V,K):mixed $function
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sortByDesc(callable $function, int $flags = \SORT_REGULAR): self
     {
@@ -280,7 +280,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sortKeys(int $flags = \SORT_REGULAR): self
     {
@@ -292,7 +292,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function sortKeysDesc(int $flags = \SORT_REGULAR): self
     {
@@ -308,7 +308,7 @@ final class ArrayCollection implements Collection
      *
      * @param iterable<array-key,T> $values
      *
-     * @return self<V&array-key,T>
+     * @return self<T,V&array-key>
      */
     public function combine(iterable $values): self
     {
@@ -316,7 +316,7 @@ final class ArrayCollection implements Collection
     }
 
     /**
-     * @return self<V&array-key,V>
+     * @return self<V,V&array-key>
      */
     public function combineWithSelf(): self
     {
@@ -328,7 +328,7 @@ final class ArrayCollection implements Collection
      *
      * @param callable(V,K):T $function
      *
-     * @return self<array-key,non-empty-list<V>>
+     * @return self<non-empty-list<V>>
      */
     public function groupBy(callable $function): self
     {
@@ -360,7 +360,7 @@ final class ArrayCollection implements Collection
      * @param K $key
      * @param V $value
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function set(int|string $key, mixed $value): self
     {
@@ -373,7 +373,7 @@ final class ArrayCollection implements Collection
     /**
      * @param K ...$keys
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function unset(int|string ...$keys): self
     {
@@ -389,7 +389,7 @@ final class ArrayCollection implements Collection
     /**
      * @param K ...$keys
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function only(int|string ...$keys): self
     {
@@ -399,7 +399,7 @@ final class ArrayCollection implements Collection
     /**
      * @param V ...$values
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function push(mixed ...$values): self
     {

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -312,7 +312,7 @@ final class ArrayCollection implements Collection
      */
     public function combine(iterable $values): self
     {
-        return new self(\array_combine($this->source, self::for($values)->source)); // @phpstan-ignore-line
+        return new self(\array_combine($this->source, self::for($values)->source)); // @phpstan-ignore return.type, argument.type
     }
 
     /**
@@ -328,7 +328,7 @@ final class ArrayCollection implements Collection
      *
      * @param callable(V,K):T $function
      *
-     * @return self<array-key,non-empty-array<int,V>>
+     * @return self<array-key,non-empty-list<V>>
      */
     public function groupBy(callable $function): self
     {
@@ -365,7 +365,7 @@ final class ArrayCollection implements Collection
     public function set(int|string $key, mixed $value): self
     {
         $clone = clone $this;
-        $clone->source[$key] = $value;
+        $clone->source[$key] = $value; // @phpstan-ignore property.readOnlyByPhpDocAssignNotInConstructor
 
         return $clone;
     }
@@ -380,7 +380,7 @@ final class ArrayCollection implements Collection
         $clone = clone $this;
 
         foreach ($keys as $key) {
-            unset($clone->source[$key]);
+            unset($clone->source[$key]); // @phpstan-ignore property.readOnlyByPhpDocAssignNotInConstructor
         }
 
         return $clone;
@@ -406,7 +406,7 @@ final class ArrayCollection implements Collection
         $clone = clone $this;
 
         foreach ($values as $value) {
-            $clone->source[] = $value;
+            $clone->source[] = $value; // @phpstan-ignore property.readOnlyByPhpDocAssignNotInConstructor
         }
 
         return $clone;

--- a/src/Collection/CallbackCollection.php
+++ b/src/Collection/CallbackCollection.php
@@ -16,16 +16,16 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
- * @implements Collection<K,V>
+ * @template K = array-key
+ * @implements Collection<V,K>
  */
 final class CallbackCollection implements Collection
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection;
 
-    /** @var LazyCollection<K,V> */
+    /** @var LazyCollection<V,K> */
     private LazyCollection $iterator;
     private \Closure $count;
 

--- a/src/Collection/ChainCollection.php
+++ b/src/Collection/ChainCollection.php
@@ -16,20 +16,20 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
- * @implements Collection<K,V>
+ * @template K = array-key
+ * @implements Collection<V,K>
  */
 final class ChainCollection implements Collection
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection;
 
-    /** @var Collection<int,Collection<K,V>> */
+    /** @var Collection<Collection<V,K>,int> */
     private Collection $collections;
 
     /**
-     * @param iterable<Collection<K,V>> $collections
+     * @param iterable<Collection<V,K>> $collections
      * @param bool                      $preserveKeys Whether to preserve the keys of the inner collections
      *                                                when iterating.
      *                                                !NOTE! data may be lost when converting to array

--- a/src/Collection/ChainCollection.php
+++ b/src/Collection/ChainCollection.php
@@ -50,13 +50,13 @@ final class ChainCollection implements Collection
             }
 
             foreach ($collection as $item) {
-                yield $item; // @phpstan-ignore-line
+                yield $item; // @phpstan-ignore generator.keyType
             }
         }
     }
 
     public function count(): int
     {
-        return $this->collections->reduce(fn(int $r, Collection $c) => $r + $c->count(), 0);
+        return $this->collections->reduce(fn(int $r, Collection $c) => $r + $c->count(), 0); // @phpstan-ignore return.type
     }
 }

--- a/src/Collection/Doctrine/DoctrineBridgeCollection.php
+++ b/src/Collection/Doctrine/DoctrineBridgeCollection.php
@@ -25,15 +25,15 @@ use Zenstruck\Collection\Matchable;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K of array-key
  * @template V
- * @implements Collection<K,V>
+ * @template K of array-key = array-key
+ * @implements Collection<V,K>
  * @implements DoctrineCollection<K,V>
- * @implements Matchable<K,V>
+ * @implements Matchable<V,K>
  */
 final class DoctrineBridgeCollection implements Collection, DoctrineCollection, Matchable
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection {
         map as private innerMap;
         reduce as private innerReduce;
@@ -96,7 +96,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
     /**
      * @param Criteria|callable(V,K):bool $specification
      *
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function filter(mixed $specification): self
     {
@@ -121,7 +121,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function map(\Closure|callable $function): self
     {
@@ -129,7 +129,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
     }
 
     /**
-     * @return self<K,V>
+     * @return self<V,K>
      */
     public function take(int $limit, int $offset = 0): self
     {

--- a/src/Collection/Doctrine/DoctrineBridgeCollection.php
+++ b/src/Collection/Doctrine/DoctrineBridgeCollection.php
@@ -65,7 +65,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
             return $this->slice(0, 1)[0] ?? $default;
         }
 
-        return $this->inner->first() ?? $default; // @phpstan-ignore-line
+        return $this->inner->first() ?? $default; // @phpstan-ignore return.type
     }
 
     public function findFirst(\Closure $p): mixed
@@ -125,7 +125,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
      */
     public function map(\Closure|callable $function): self
     {
-        return new self($this->innerMap($function)); // @phpstan-ignore-line
+        return new self($this->innerMap($function)); // @phpstan-ignore return.type
     }
 
     /**

--- a/src/Collection/Doctrine/ORM/EntityRepository.php
+++ b/src/Collection/Doctrine/ORM/EntityRepository.php
@@ -46,7 +46,7 @@ class EntityRepository implements ObjectRepository
             }
 
             if (\is_array($specification) && !\array_is_list($specification)) {
-                return $this->em()->getUnitOfWork()->getEntityPersister($this->class)->load($specification, limit: 1); // @phpstan-ignore-line
+                return $this->em()->getUnitOfWork()->getEntityPersister($this->class)->load($specification, limit: 1); // @phpstan-ignore return.type
             }
 
             if (\is_callable($specification) && \is_object($specification)) {
@@ -57,7 +57,7 @@ class EntityRepository implements ObjectRepository
 
             if (\is_object($specification)) {
                 try {
-                    return QueryBuilderInterpreter::interpret($specification, static::class, __FUNCTION__, $this->qb(), 'e') // @phpstan-ignore-line
+                    return QueryBuilderInterpreter::interpret($specification, static::class, __FUNCTION__, $this->qb(), 'e') // @phpstan-ignore return.type
                         ->result()
                         ->first()
                     ;
@@ -136,7 +136,7 @@ class EntityRepository implements ObjectRepository
         }
 
         if (\is_object($specification)) {
-            return QueryBuilderInterpreter::interpret($specification, static::class, $method, $qb, 'e') // @phpstan-ignore-line
+            return QueryBuilderInterpreter::interpret($specification, static::class, $method, $qb, 'e') // @phpstan-ignore return.type
                 ->result()
             ;
         }

--- a/src/Collection/Doctrine/ORM/EntityResult.php
+++ b/src/Collection/Doctrine/ORM/EntityResult.php
@@ -37,7 +37,7 @@ use function Zenstruck\collect;
  */
 final class EntityResult implements Result
 {
-    /** @use IterableCollection<int,V> */
+    /** @use IterableCollection<V,int> */
     use IterableCollection {
         find as private innerFind;
         filter as private innerFilter;

--- a/src/Collection/Doctrine/ORM/EntityResult.php
+++ b/src/Collection/Doctrine/ORM/EntityResult.php
@@ -49,10 +49,12 @@ final class EntityResult implements Result
     private $resultModifier;
 
     /** @var Query::HYDRATE_*|null */
-    private ?int $hydrationMode = null;
+    private ?int $hydrationMode = null; // @phpstan-ignore property.unusedType, property.unusedType, property.unusedType, property.unusedType
     private bool $fetchJoins = true;
 
     private bool $readonly = false;
+
+    /** @var non-negative-int */
     private int $count;
     private ?bool $useOutputWalkers = null;
 
@@ -222,7 +224,7 @@ final class EntityResult implements Result
      */
     public function withAggregates(): self
     {
-        return $this->as(self::ENTITY_WITH_AGGREGATES); // @phpstan-ignore-line
+        return $this->as(self::ENTITY_WITH_AGGREGATES); // @phpstan-ignore return.type
     }
 
     /**

--- a/src/Collection/Doctrine/ObjectRepository.php
+++ b/src/Collection/Doctrine/ObjectRepository.php
@@ -19,7 +19,7 @@ use Zenstruck\Collection\Matchable;
  * @author Kevin Bond <kevinbond@gmail.com>
  *
  * @template V of object
- * @extends Matchable<int,V>
+ * @extends Matchable<V,int>
  * @extends \IteratorAggregate<int,V>
  */
 interface ObjectRepository extends Matchable, \Countable, \IteratorAggregate

--- a/src/Collection/Doctrine/Result.php
+++ b/src/Collection/Doctrine/Result.php
@@ -22,8 +22,8 @@ use Zenstruck\Collection\Matchable;
  *
  * @immutable
  * @template V
- * @extends Collection<int,V>
- * @extends Matchable<int,V>
+ * @extends Collection<V,int>
+ * @extends Matchable<V,int>
  */
 interface Result extends Collection, Matchable
 {

--- a/src/Collection/FactoryCollection.php
+++ b/src/Collection/FactoryCollection.php
@@ -16,23 +16,23 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
- * @implements Collection<K,V>
+ * @template K = array-key
+ * @implements Collection<V,K>
  */
 final class FactoryCollection implements Collection
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection;
 
-    /** @var Collection<K,mixed> */
+    /** @var Collection<mixed,K> */
     private Collection $inner;
     private \Closure $factory;
 
     /**
      * @template T
      *
-     * @param Collection<K,T> $collection
+     * @param Collection<T,K> $collection
      * @param callable(T):V   $factory
      */
     public function __construct(Collection $collection, callable $factory)

--- a/src/Collection/Grid.php
+++ b/src/Collection/Grid.php
@@ -94,7 +94,7 @@ final class Grid implements \IteratorAggregate
     }
 
     /**
-     * @return list<object|null>
+     * @return array<int,object|null>
      */
     private function filterSpecification(): array
     {

--- a/src/Collection/Grid.php
+++ b/src/Collection/Grid.php
@@ -32,13 +32,13 @@ final class Grid implements \IteratorAggregate
 {
     public readonly PerPage $perPage;
 
-    /** @var Page<int,T> */
+    /** @var Page<T> */
     private Page $page;
 
     /**
      * @internal
      *
-     * @param Matchable<mixed,T> $source
+     * @param Matchable<T> $source
      */
     public function __construct(
         public readonly Input $input,
@@ -57,7 +57,7 @@ final class Grid implements \IteratorAggregate
     }
 
     /**
-     * @return Page<int,T>
+     * @return Page<T,int>
      */
     public function page(): Page
     {

--- a/src/Collection/Grid/Columns.php
+++ b/src/Collection/Grid/Columns.php
@@ -27,7 +27,7 @@ final class Columns implements \IteratorAggregate, \Countable
     /**
      * @internal
      *
-     * @param ArrayCollection<string,Column> $columns
+     * @param ArrayCollection<Column,string> $columns
      */
     public function __construct(private ArrayCollection $columns, private Input $input, private ?OrderBy $defaultSort)
     {
@@ -63,7 +63,7 @@ final class Columns implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return ArrayCollection<string,Column>
+     * @return ArrayCollection<Column,string>
      */
     public function all(): ArrayCollection
     {

--- a/src/Collection/Grid/Filter/ChoiceFilter.php
+++ b/src/Collection/Grid/Filter/ChoiceFilter.php
@@ -21,7 +21,7 @@ use Zenstruck\Collection\Grid\Filter;
  */
 final class ChoiceFilter implements Filter, \IteratorAggregate, \Countable
 {
-    /** @var ArrayCollection<string,Choice> */
+    /** @var ArrayCollection<Choice,string> */
     private ArrayCollection $choices;
 
     public function __construct(Choice ...$choices)

--- a/src/Collection/Grid/Filters.php
+++ b/src/Collection/Grid/Filters.php
@@ -20,7 +20,7 @@ use Zenstruck\Collection\ArrayCollection;
  */
 final class Filters implements \IteratorAggregate, \Countable
 {
-    /** @var ArrayCollection<string,Filter> */
+    /** @var ArrayCollection<Filter,string> */
     private ArrayCollection $filters;
 
     /**
@@ -42,7 +42,7 @@ final class Filters implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return ArrayCollection<string,Filter>
+     * @return ArrayCollection<Filter,string>
      */
     public function all(): ArrayCollection
     {

--- a/src/Collection/Grid/GridBuilder.php
+++ b/src/Collection/Grid/GridBuilder.php
@@ -26,7 +26,7 @@ use function Zenstruck\collect;
  */
 final class GridBuilder
 {
-    /** @var Matchable<mixed,T>|null */
+    /** @var Matchable<T>|null */
     public ?Matchable $source = null;
     public ?OrderBy $defaultSort = null;
     public ?PerPage $perPage = null;

--- a/src/Collection/Grid/Input.php
+++ b/src/Collection/Grid/Input.php
@@ -21,6 +21,9 @@ use Zenstruck\Collection\Specification\OrderBy;
  */
 interface Input
 {
+    /**
+     * @return positive-int
+     */
     public function page(): int;
 
     /**
@@ -32,6 +35,9 @@ interface Input
 
     public function applyQuery(?string $value): static;
 
+    /**
+     * @return positive-int|null
+     */
     public function perPage(): ?int;
 
     /**

--- a/src/Collection/Grid/Input.php
+++ b/src/Collection/Grid/Input.php
@@ -56,7 +56,7 @@ interface Input
     public function reset(): static;
 
     /**
-     * @return ArrayCollection<string,mixed>
+     * @return ArrayCollection<mixed,string>
      */
     public function values(): ArrayCollection;
 }

--- a/src/Collection/Grid/Input/UriInput.php
+++ b/src/Collection/Grid/Input/UriInput.php
@@ -58,8 +58,10 @@ final class UriInput implements Input, \Stringable
 
     public function page(): int
     {
-        if (\is_numeric($page = $this->query[self::PAGE] ?? 1)) {
-            return (int) $page;
+        $page = $this->query[self::PAGE] ?? 1;
+
+        if (\is_numeric($page) && $page > 0) {
+            return (int) $page; // @phpstan-ignore return.type
         }
 
         return 1;
@@ -90,8 +92,10 @@ final class UriInput implements Input, \Stringable
 
     public function perPage(): ?int
     {
-        if (\is_numeric($page = $this->query[self::PER_PAGE] ?? null)) {
-            return (int) $page;
+        $page = $this->query[self::PER_PAGE] ?? null;
+
+        if (\is_numeric($page) && $page > 0) {
+            return (int) $page; // @phpstan-ignore return.type
         }
 
         return null;

--- a/src/Collection/Grid/PerPage.php
+++ b/src/Collection/Grid/PerPage.php
@@ -16,5 +16,10 @@ namespace Zenstruck\Collection\Grid;
  */
 interface PerPage
 {
+    /**
+     * @param positive-int|null $input
+     *
+     * @return positive-int
+     */
     public function value(?int $input): int;
 }

--- a/src/Collection/IterableCollection.php
+++ b/src/Collection/IterableCollection.php
@@ -20,13 +20,13 @@ use Zenstruck\Collection\Exception\InvalidSpecification;
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
+ * @template K = array-key
  */
 trait IterableCollection
 {
     /**
-     * @return LazyCollection<K,V>
+     * @return LazyCollection<V,K>
      */
     public function take(int $limit, int $offset = 0): Collection
     {
@@ -66,7 +66,7 @@ trait IterableCollection
     }
 
     /**
-     * @return LazyCollection<K,V>
+     * @return LazyCollection<V,K>
      */
     public function filter(mixed $specification): Collection
     {
@@ -84,7 +84,7 @@ trait IterableCollection
     }
 
     /**
-     * @return LazyCollection<K,V>
+     * @return LazyCollection<V,K>
      */
     public function keyBy(callable $function): Collection
     {
@@ -100,7 +100,7 @@ trait IterableCollection
      *
      * @param callable(V,K):T $function
      *
-     * @return LazyCollection<K,T>
+     * @return LazyCollection<T,K>
      */
     public function map(callable $function): Collection
     {
@@ -112,7 +112,7 @@ trait IterableCollection
     }
 
     /**
-     * @return Page<K,V>
+     * @return Page<V,K>
      */
     public function paginate(int $page = 1, int $limit = Page::DEFAULT_LIMIT): Page
     {
@@ -120,7 +120,7 @@ trait IterableCollection
     }
 
     /**
-     * @return Pages<K,V>
+     * @return Pages<V,K>
      */
     public function pages(int $limit = Page::DEFAULT_LIMIT): Pages
     {

--- a/src/Collection/LazyCollection.php
+++ b/src/Collection/LazyCollection.php
@@ -38,10 +38,10 @@ final class LazyCollection implements Collection
         }
 
         if (\is_callable($source) && (!\is_iterable($source) || \is_array($source))) {
-            $source = $source(...); // @phpstan-ignore-line
+            $source = $source(...); // @phpstan-ignore callable.nonCallable
         }
 
-        $this->source = \is_array($source) ? new \ArrayIterator($source) : $source; // @phpstan-ignore-line
+        $this->source = \is_array($source) ? new \ArrayIterator($source) : $source; // @phpstan-ignore assign.propertyType
     }
 
     /**

--- a/src/Collection/LazyCollection.php
+++ b/src/Collection/LazyCollection.php
@@ -16,13 +16,13 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
- * @implements Collection<K,V>
+ * @template K = array-key
+ * @implements Collection<V,K>
  */
 final class LazyCollection implements Collection
 {
-    /** @use IterableCollection<K,V> */
+    /** @use IterableCollection<V,K> */
     use IterableCollection;
 
     /** @var \Traversable<K,V>|\Closure():iterable<K,V> */

--- a/src/Collection/Matchable.php
+++ b/src/Collection/Matchable.php
@@ -17,8 +17,8 @@ use Zenstruck\Collection\Exception\InvalidSpecification;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
+ * @template K = array-key
  */
 interface Matchable
 {
@@ -30,7 +30,7 @@ interface Matchable
     public function find(object $specification): mixed;
 
     /**
-     * @return Collection<K,V>
+     * @return Collection<V,K>
      */
     public function filter(mixed $specification): Collection;
 }

--- a/src/Collection/Page.php
+++ b/src/Collection/Page.php
@@ -16,8 +16,8 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
+ * @template K = array-key
  * @implements \IteratorAggregate<K,V>
  */
 final class Page implements \IteratorAggregate, \Countable
@@ -31,11 +31,11 @@ final class Page implements \IteratorAggregate, \Countable
     private int $limit;
     private bool $strict = false;
 
-    /** @var Collection<K,V> */
+    /** @var Collection<V,K> */
     private Collection $cachedPage;
 
     /**
-     * @param Collection<K,V> $collection
+     * @param Collection<V,K> $collection
      * @param positive-int    $page
      * @param positive-int    $limit
      */
@@ -160,7 +160,7 @@ final class Page implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return Collection<K,V>
+     * @return Collection<V,K>
      */
     private function getPage(): Collection
     {

--- a/src/Collection/Page.php
+++ b/src/Collection/Page.php
@@ -24,7 +24,10 @@ final class Page implements \IteratorAggregate, \Countable
 {
     public const DEFAULT_LIMIT = 20;
 
+    /** @var positive-int */
     private int $page;
+
+    /** @var positive-int */
     private int $limit;
     private bool $strict = false;
 
@@ -33,6 +36,8 @@ final class Page implements \IteratorAggregate, \Countable
 
     /**
      * @param Collection<K,V> $collection
+     * @param positive-int    $page
+     * @param positive-int    $limit
      */
     public function __construct(private Collection $collection, int $page = 1, int $limit = self::DEFAULT_LIMIT)
     {
@@ -74,6 +79,9 @@ final class Page implements \IteratorAggregate, \Countable
         return $this->page;
     }
 
+    /**
+     * @return positive-int
+     */
     public function limit(): int
     {
         return $this->limit;
@@ -124,6 +132,9 @@ final class Page implements \IteratorAggregate, \Countable
         return 1;
     }
 
+    /**
+     * @return positive-int
+     */
     public function lastPage(): int
     {
         $totalCount = $this->totalCount();
@@ -132,9 +143,12 @@ final class Page implements \IteratorAggregate, \Countable
             return 1;
         }
 
-        return (int) \ceil($totalCount / $this->limit());
+        return (int) \ceil($totalCount / $this->limit()); // @phpstan-ignore return.type
     }
 
+    /**
+     * @return positive-int
+     */
     public function pageCount(): int
     {
         return $this->lastPage();

--- a/src/Collection/Pagerfanta/PagerfantaAdapter.php
+++ b/src/Collection/Pagerfanta/PagerfantaAdapter.php
@@ -35,7 +35,7 @@ final class PagerfantaAdapter implements AdapterInterface
 
     public function getNbResults(): int
     {
-        return $this->collection->count(); // @phpstan-ignore-line
+        return $this->collection->count();
     }
 
     public function getSlice($offset, $length): iterable

--- a/src/Collection/Pages.php
+++ b/src/Collection/Pages.php
@@ -16,17 +16,17 @@ use Zenstruck\Collection;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  *
- * @template K
  * @template V
- * @implements \IteratorAggregate<int,Page<K,V>>
+ * @template K = array-key
+ * @implements \IteratorAggregate<int,Page<V,K>>
  */
 final class Pages implements \IteratorAggregate, \Countable
 {
-    /** @var Page<K,V> */
+    /** @var Page<V,K> */
     private Page $page1;
 
     /**
-     * @param Collection<K,V> $collection
+     * @param Collection<V,K> $collection
      * @param positive-int    $limit
      */
     public function __construct(private Collection $collection, private int $limit = Page::DEFAULT_LIMIT)
@@ -36,7 +36,7 @@ final class Pages implements \IteratorAggregate, \Countable
     /**
      * @param positive-int $page
      *
-     * @return Page<K,V>
+     * @return Page<V,K>
      */
     public function get(int $page): Page
     {
@@ -64,7 +64,7 @@ final class Pages implements \IteratorAggregate, \Countable
     }
 
     /**
-     * @return Page<K,V>
+     * @return Page<V,K>
      */
     private function page1(): Page
     {

--- a/src/Collection/Pages.php
+++ b/src/Collection/Pages.php
@@ -27,12 +27,15 @@ final class Pages implements \IteratorAggregate, \Countable
 
     /**
      * @param Collection<K,V> $collection
+     * @param positive-int    $limit
      */
     public function __construct(private Collection $collection, private int $limit = Page::DEFAULT_LIMIT)
     {
     }
 
     /**
+     * @param positive-int $page
+     *
      * @return Page<K,V>
      */
     public function get(int $page): Page

--- a/src/Collection/Symfony/Doctrine/ChainObjectRepositoryFactory.php
+++ b/src/Collection/Symfony/Doctrine/ChainObjectRepositoryFactory.php
@@ -31,7 +31,7 @@ final class ChainObjectRepositoryFactory implements ObjectRepositoryFactory, Res
 
     public function create(string $class): ObjectRepository
     {
-        return $this->cache[$class] ??= $this->inner->create($class); // @phpstan-ignore-line
+        return $this->cache[$class] ??= $this->inner->create($class); // @phpstan-ignore return.type
     }
 
     public function reset(): void

--- a/src/Collection/Symfony/ZenstruckCollectionBundle.php
+++ b/src/Collection/Symfony/ZenstruckCollectionBundle.php
@@ -58,10 +58,10 @@ final class ZenstruckCollectionBundle extends AbstractBundle implements Compiler
             $definition->addTag('zenstruck_collection.grid_definition', ['key' => $attribute->name]);
         });
 
-        if (isset($builder->getParameter('kernel.bundles')['DoctrineBundle'])) { // @phpstan-ignore-line
+        if (isset($builder->getParameter('kernel.bundles')['DoctrineBundle'])) { // @phpstan-ignore offsetAccess.nonOffsetAccessible
             $loader->load('doctrine.php');
 
-            $builder->registerAttributeForAutoconfiguration(ForObject::class, function(ChildDefinition $definition, ForObject $attribute, \ReflectionClass $class) { // @phpstan-ignore-line
+            $builder->registerAttributeForAutoconfiguration(ForObject::class, function(ChildDefinition $definition, ForObject $attribute, \ReflectionClass $class) { // @phpstan-ignore argument.type
                 if ($class->implementsInterface(GridDefinition::class)) {
                     $definition->addTag('zenstruck_collection.grid_definition', ['key' => $attribute->class, 'as_object' => true]);
 
@@ -83,7 +83,7 @@ final class ZenstruckCollectionBundle extends AbstractBundle implements Compiler
 
     public function process(ContainerBuilder $container): void
     {
-        if (!isset($container->getParameter('kernel.bundles')['DoctrineBundle'])) { // @phpstan-ignore-line
+        if (!isset($container->getParameter('kernel.bundles')['DoctrineBundle'])) { // @phpstan-ignore offsetAccess.nonOffsetAccessible
             return;
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -17,13 +17,13 @@ use Zenstruck\Collection\Doctrine\DoctrineBridgeCollection;
 use Zenstruck\Collection\LazyCollection;
 
 /**
- * @template K
  * @template V
+ * @template K
  *
  * @param null|iterable<K,V>|callable():iterable<K,V> $source
  *
- * @return Collection<K,V>
- * @phpstan-return ($source is null ? Collection<never,never> : ($source is array ? ArrayCollection<K&array-key,V> : ($source is DoctrineCollection<K&array-key,V> ? DoctrineBridgeCollection<K&array-key,V> : Collection<K,V>)))
+ * @return Collection<V,K>
+ * @phpstan-return ($source is null ? Collection<never,never> : ($source is array ? ArrayCollection<V> : ($source is DoctrineCollection<K&array-key,V> ? DoctrineBridgeCollection<V> : Collection<V,K>)))
  */
 function collect(iterable|callable|null $source = null): Collection
 {

--- a/stubs/Types.php
+++ b/stubs/Types.php
@@ -8,7 +8,7 @@ use Zenstruck\Collection\LazyCollection;
 use function PHPStan\Testing\assertType;
 use function Zenstruck\collect;
 
-assertType('Zenstruck\Collection\LazyCollection<int, User>', new LazyCollection([new User]));
+assertType('Zenstruck\Collection\LazyCollection<User, int>', new LazyCollection([new User]));
 
 /** @var ObjectRepository<User> $objectRepository */
 
@@ -23,7 +23,7 @@ assertType('Zenstruck\Collection\Doctrine\Result<int>', $objectRepository->query
 assertType('Zenstruck\Collection\Doctrine\Result<float>', $objectRepository->query(null)->asFloat());
 assertType('Zenstruck\Collection\Doctrine\Result<array<string, mixed>>', $objectRepository->query(null)->asArray());
 assertType('Zenstruck\Collection\Doctrine\Result<int>', $objectRepository->query(null)->as(fn(): int => 1));
-assertType('Zenstruck\Collection\Page<int, User>', $objectRepository->query(null)->paginate());
+assertType('Zenstruck\Collection\Page<User, int>', $objectRepository->query(null)->paginate());
 
 /** @var EntityRepository<User> $ormRepository */
 
@@ -39,15 +39,15 @@ assertType('Zenstruck\Collection<never, never>', collect());
 
 /**
  * @param User[]|null $users
- * @return Collection<int, User>
+ * @return Collection<User>
  */
 function get_users(array|null $users): Collection
 {
     return collect($users);
 }
 
-assertType('Zenstruck\Collection<int, User>', get_users(null));
-assertType('Zenstruck\Collection<int, User>', get_users([]));
-assertType('Zenstruck\Collection<int, User>', get_users([new User()]));
-assertType('Zenstruck\Collection<int, User>', get_users([new User()])->dump());
+assertType('Zenstruck\Collection<User, (int|string)>', get_users(null));
+assertType('Zenstruck\Collection<User, (int|string)>', get_users([]));
+assertType('Zenstruck\Collection<User, (int|string)>', get_users([new User()]));
+assertType('Zenstruck\Collection<User, (int|string)>', get_users([new User()])->dump());
 assertType('never', get_users([new User()])->dd());


### PR DESCRIPTION
> [!NOTE]
> This is only a BC break for static analysis.

Since 90+% of the time, you don't really care about the key when using `Collection`, I've swapped the `@template` for these two values and used [PHPStan's default template type](https://x.com/OndrejMirtes/status/1843920480342057154) (as `array-key`) for the key:

Before:

```
@return Collection<array-key,object>
```

After:

```
@return Collection<object>
```

If you still want to define the key, it's the second template:

```
@return Collection<object,int>
```