### PR TITLE
Add PHP 8.5 and remove Symfony 7.2 run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        php: [ 8.1, 8.2, 8.3, 8.4, 8.5 ]
         deps: [ highest ]
-        symfony: [ 6.4.*, 7.2.*, 7.3.* ]
+        symfony: [ 6.4.*, 7.3.* ]
         include:
           - php: 8.1
             deps: lowest
             symfony: '*'
         exclude:
-          - php: 8.1
-            symfony: 7.2.*
           - php: 8.1
             symfony: 7.3.*
     steps:


### PR DESCRIPTION
are the testsruns for symfony 7.2 still needed?
Because of latest composer changes this will probably needs changes in ci workflow