### PR TITLE
fix: array callables + `collect()`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,7 @@ use Zenstruck\Collection\LazyCollection;
  * @param null|iterable<K,V>|callable():iterable<K,V> $source
  *
  * @return Collection<V,K>
- * @phpstan-return ($source is null ? Collection<never,never> : ($source is array ? ArrayCollection<V> : ($source is DoctrineCollection<K&array-key,V> ? DoctrineBridgeCollection<V> : Collection<V,K>)))
+ * @phpstan-return ($source is null ? Collection<never,never> : ($source is callable ? Collection<V,K> : ($source is array ? ArrayCollection<V> : ($source is DoctrineCollection<K&array-key,V> ? DoctrineBridgeCollection<V> : Collection<V,K>))))
  */
 function collect(iterable|callable|null $source = null): Collection
 {
@@ -33,6 +33,10 @@ function collect(iterable|callable|null $source = null): Collection
 
     if ($source instanceof DoctrineCollection) {
         return new DoctrineBridgeCollection($source);
+    }
+
+    if (\is_callable($source)) {
+        return new LazyCollection($source(...));
     }
 
     if (\is_array($source)) {

--- a/stubs/Types.php
+++ b/stubs/Types.php
@@ -36,6 +36,9 @@ class User
 
 assertType('Zenstruck\Collection<never, never>', collect());
 assertType('Zenstruck\Collection<never, never>', collect());
+assertType('Zenstruck\Collection\ArrayCollection<User, (int|string)>', collect([new User()]));
+assertType('Zenstruck\Collection<User, int>', collect(fn() => [new User()]));
+assertType('Zenstruck\Collection<User, int>', collect(new \ArrayIterator([new User()])));
 
 /**
  * @param User[]|null $users

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -11,7 +11,11 @@
 
 namespace Zenstruck\Collection\Tests;
 
+use Doctrine\Common\Collections\ArrayCollection as DoctrineArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\ArrayCollection;
+use Zenstruck\Collection\Doctrine\DoctrineBridgeCollection;
+use Zenstruck\Collection\LazyCollection;
 
 use function Zenstruck\collect;
 
@@ -29,4 +33,111 @@ final class FunctionsTest extends TestCase
         $this->assertSame([], collect()->eager()->all());
         $this->assertSame([], collect(null)->eager()->all());
     }
+
+    /**
+     * @test
+     */
+    public function collect_arrays_as_array_collection(): void
+    {
+        $this->assertInstanceOf(ArrayCollection::class, collect([]));
+        $this->assertInstanceOf(ArrayCollection::class, collect(['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function collect_invokes_array_callables(): void
+    {
+        $this->assertInstanceOf(LazyCollection::class, collect([$this, 'items']));
+        $this->assertSame(['foo' => 'bar'], collect([$this, 'items'])->eager()->all());
+
+        $this->assertInstanceOf(LazyCollection::class, collect([self::class, 'staticItems']));
+        $this->assertSame(['foo' => 'bar'], collect([self::class, 'staticItems'])->eager()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function collect_treats_non_callable_arrays_as_arrays(): void
+    {
+        $source = ['foo', 'bar'];
+
+        $this->assertInstanceOf(ArrayCollection::class, collect($source));
+        $this->assertSame($source, collect($source)->eager()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function collect_non_array_callables_as_lazy_collection(): void
+    {
+        $invokable = new class {
+            public function __invoke(): iterable
+            {
+                return ['foo' => 'bar'];
+            }
+        };
+
+        $this->assertInstanceOf(LazyCollection::class, collect(fn() => ['foo' => 'bar']));
+        $this->assertSame(['foo' => 'bar'], collect(fn() => ['foo' => 'bar'])->eager()->all());
+
+        $this->assertInstanceOf(LazyCollection::class, collect($invokable));
+        $this->assertSame(['foo' => 'bar'], collect($invokable)->eager()->all());
+
+        $this->assertInstanceOf(LazyCollection::class, collect('Zenstruck\Collection\Tests\items'));
+        $this->assertSame(['foo' => 'bar'], collect('Zenstruck\Collection\Tests\items')->eager()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function collect_traversables_as_lazy_collection(): void
+    {
+        $collection = collect(new \ArrayIterator(['foo' => 'bar']));
+
+        $this->assertInstanceOf(LazyCollection::class, $collection);
+        $this->assertSame(['foo' => 'bar'], $collection->eager()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function collect_doctrine_collections_as_doctrine_bridge_collection(): void
+    {
+        $collection = collect(new DoctrineArrayCollection(['foo' => 'bar']));
+
+        $this->assertInstanceOf(DoctrineBridgeCollection::class, $collection);
+        $this->assertSame(['foo' => 'bar'], $collection->eager()->all());
+    }
+
+    /**
+     * @test
+     */
+    public function collect_returns_collections_as_is(): void
+    {
+        $collection = ArrayCollection::for(['foo' => 'bar']);
+
+        $this->assertSame($collection, collect($collection));
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function items(): array
+    {
+        return ['foo' => 'bar'];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public static function staticItems(): array
+    {
+        return ['foo' => 'bar'];
+    }
+}
+
+function items(): iterable
+{
+    return ['foo' => 'bar'];
 }


### PR DESCRIPTION
This pull request enhances the `collect()` function to handle callable sources more robustly and improves type safety and test coverage. The main focus is on distinguishing between arrays and callables, ensuring the correct collection type is returned, and thoroughly testing these behaviors.

**Enhancements to `collect()` function:**

- Improved callable detection and handling:
  * The PHPStan return type annotation for `collect()` was updated to correctly prioritize callables over arrays, ensuring that callable sources are always treated as such.
  * The implementation now checks if the source is callable before checking for arrays, returning a `LazyCollection` when appropriate.

**Testing improvements:**

- Added comprehensive tests for `collect()`:
  * New tests verify that callables, arrays, traversables, Doctrine collections, and already-instantiated collections are handled as expected, ensuring correct instantiation and behavior for each source type.
  * Helper methods and global functions were added to support these new test cases.
  * Additional type assertions were added to the stubs to verify static analysis expectations for various usages of `collect()`.

**Test utilities and imports:**

- Added necessary imports for new collection types to the test suite, supporting the expanded test coverage.