### PR TITLE
fix: several bugs found while writing the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ $updated = EntityResultQueryBuilder::forEntity($em, Post::class, 'p')
 going to read - nothing is tracked for changes, and nothing is flushed:
 
 ```php
-foreach ($result->readonly()->paginate() as $post) {
+foreach ($result->readonly() as $post) {
     // $post is not managed
 }
 ```
@@ -1035,10 +1035,18 @@ A leading or trailing `*` is stripped - the specification already adds one on th
 Spec::contains('title', '*symfony*'); // identical to Spec::contains('title', 'symfony')
 ```
 
+`*` is the _only_ wildcard. SQL's own wildcards are escaped, so they match literally and user input is safe to
+pass straight through:
+
+```php
+Spec::contains('title', '50%');     // titles containing "50%"
+Spec::startsWith('code', 'a_b');    // codes starting with "a_b" - the underscore isn't a wildcard
+```
+
 > [!WARNING]
-> Wildcards are only interpreted by [repositories](#repositories). An [`EntityResult`](#entityresult) or a
-> [bridged collection](#collection-bridge) passes the value straight through to the `Criteria`, where `*`
-> matches a literal asterisk.
+> All of this is repository-only. An [`EntityResult`](#entityresult) or a
+> [bridged collection](#collection-bridge) passes the value straight through to the `Criteria`, so `*` matches
+> a literal asterisk and `%`/`_` are left to the database as wildcards.
 
 #### What Understands What
 
@@ -1096,11 +1104,15 @@ $posts->filter(Spec::callback(
 ));
 ```
 
-An `EntityResult` or a bridged collection gives you the `Criteria` instead. Return an `Expression` and it gets
-added to it:
+An `EntityResult` or a bridged collection gives you the `Criteria` instead. Either modify it directly or
+return an `Expression` to have it added for you:
 
 ```php
 use Doctrine\Common\Collections\Criteria;
+
+$comments->filter(Spec::callback(
+    fn(Criteria $criteria) => $criteria->andWhere(Criteria::expr()->gt('score', 10)),
+));
 
 $comments->filter(Spec::callback(
     fn(Criteria $criteria) => Criteria::expr()->gt('score', 10),

--- a/src/Collection/Doctrine/DoctrineBridgeCollection.php
+++ b/src/Collection/Doctrine/DoctrineBridgeCollection.php
@@ -104,7 +104,7 @@ final class DoctrineBridgeCollection implements Collection, DoctrineCollection, 
             return new self($this->inner->matching($specification));
         }
 
-        if ($this->inner instanceof Criteria) {
+        if ($specification instanceof Criteria) {
             throw new \LogicException(\sprintf('"%s" is not an instance of "%s". Cannot use Criteria as a specification.', $this->inner::class, Selectable::class));
         }
 

--- a/src/Collection/Doctrine/ORM/EntityResult.php
+++ b/src/Collection/Doctrine/ORM/EntityResult.php
@@ -65,6 +65,8 @@ final class EntityResult implements Result
     public function __clone(): void
     {
         $this->qb = clone $this->qb;
+
+        unset($this->count); // the clone may not have the same number of results
     }
 
     public function batchIterate(int $chunkSize = 100): \Traversable

--- a/src/Collection/Doctrine/ORM/EntityResult.php
+++ b/src/Collection/Doctrine/ORM/EntityResult.php
@@ -283,8 +283,8 @@ final class EntityResult implements Result
         try {
             $iterator = $this->query()->toIterable(hydrationMode: $this->hydrationMode ?? Query::HYDRATE_OBJECT);
 
-            if ($this->resultModifier) {
-                $iterator = collect(static fn() => yield from $iterator)->map($this->resultModifier);
+            if ($this->resultModifier || $this->readonly) {
+                $iterator = collect(static fn() => yield from $iterator)->map($this->normalizeResult(...));
             }
 
             yield from $iterator;

--- a/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
+++ b/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
@@ -47,6 +47,8 @@ use Zenstruck\Collection\Specification\OrderBy;
  */
 final class QueryBuilderInterpreter
 {
+    private const LIKE_ESCAPE = '!';
+
     /**
      * @param EntityResultQueryBuilder<object> $qb
      * @param class-string                     $callingClass
@@ -99,9 +101,9 @@ final class QueryBuilderInterpreter
             GreaterThanOrEqualTo::class => $this->qb->expr()->gte($this->prefix($specification->field), $this->param($specification->value)),
             In::class => $this->qb->expr()->in($this->prefix($specification->field), $this->param($specification->value)),
             IsNull::class => $this->qb->expr()->isNull($this->prefix($specification->field)),
-            Contains::class => $this->qb->expr()->like($this->prefix($specification->field), $this->param('%'.self::normalizeLike($specification).'%')),
-            StartsWith::class => $this->qb->expr()->like($this->prefix($specification->field), $this->param(self::normalizeLike($specification).'%')),
-            EndsWith::class => $this->qb->expr()->like($this->prefix($specification->field), $this->param('%'.self::normalizeLike($specification))),
+            Contains::class => $this->like($specification, '%', '%'),
+            StartsWith::class => $this->like($specification, '', '%'),
+            EndsWith::class => $this->like($specification, '%', ''),
             Between::class => $this->interpretBetween($specification),
 
             Callback::class => ($specification->value)($this->qb, $this->alias),
@@ -191,9 +193,25 @@ final class QueryBuilderInterpreter
         );
     }
 
-    private static function normalizeLike(Comparison $comparison): string
+    /**
+     * Escapes the SQL wildcards in the value, then converts the user-facing
+     * wildcard (*) into a real one. Leading/trailing wildcards are trimmed
+     * as $prefix/$suffix already add them where required.
+     */
+    private function like(Comparison $comparison, string $prefix, string $suffix): string
     {
-        return \str_replace(['%', '*'], ['%%', '%'], \trim($comparison->value, '*')); // todo make wildcard char configurable?
+        $value = \str_replace(
+            [self::LIKE_ESCAPE, '%', '_', '*'], // todo make wildcard char configurable?
+            [self::LIKE_ESCAPE.self::LIKE_ESCAPE, self::LIKE_ESCAPE.'%', self::LIKE_ESCAPE.'_', '%'],
+            \trim($comparison->value, '*'),
+        );
+
+        return \sprintf(
+            '%s LIKE %s ESCAPE %s',
+            $this->prefix($comparison->field),
+            $this->param($prefix.$value.$suffix),
+            $this->qb->expr()->literal(self::LIKE_ESCAPE),
+        );
     }
 
     private function param(mixed $value): string

--- a/src/Collection/Doctrine/Specification/CriteriaInterpreter.php
+++ b/src/Collection/Doctrine/Specification/CriteriaInterpreter.php
@@ -97,7 +97,8 @@ final class CriteriaInterpreter
             StartsWith::class => Criteria::expr()->startsWith($specification->field, $specification->value),
             Between::class => $this->transform($specification->asAnd()),
 
-            Callback::class => ($specification->value)($this->criteria),
+            // the callback can modify the criteria directly - only use its return value if it's an expression
+            Callback::class => ($value = ($specification->value)($this->criteria)) instanceof Expression ? $value : null,
 
             default => throw InvalidSpecification::build($specification, $this->class, $this->method),
         };

--- a/tests/Doctrine/DoctrineBridgeCollectionTest.php
+++ b/tests/Doctrine/DoctrineBridgeCollectionTest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection\Doctrine\DoctrineBridgeCollection;
 use Zenstruck\Collection\LazyCollection;
+use Zenstruck\Collection\Spec;
 use Zenstruck\Collection\Tests\CollectionTests;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Relation;
@@ -36,6 +37,30 @@ final class DoctrineBridgeCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->collection = new DoctrineBridgeCollection();
+    }
+
+    /**
+     * @test
+     */
+    public function callback_specification_can_return_an_expression(): void
+    {
+        $collection = $this->createWithItems(3)->filter(
+            Spec::callback(static fn(Criteria $criteria) => Criteria::expr()->lt('id', 3)),
+        );
+
+        $this->assertCount(2, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function callback_specification_can_modify_the_criteria(): void
+    {
+        $collection = $this->createWithItems(3)->filter(
+            Spec::callback(static fn(Criteria $criteria) => $criteria->andWhere(Criteria::expr()->lt('id', 3))),
+        );
+
+        $this->assertCount(2, $collection);
     }
 
     /**

--- a/tests/Doctrine/DoctrineBridgeCollectionTest.php
+++ b/tests/Doctrine/DoctrineBridgeCollectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Collection\Tests\Doctrine;
 
+use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\PersistentCollection;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +36,19 @@ final class DoctrineBridgeCollectionTest extends TestCase
     protected function setUp(): void
     {
         $this->collection = new DoctrineBridgeCollection();
+    }
+
+    /**
+     * @test
+     */
+    public function criteria_specification_requires_a_selectable_inner_collection(): void
+    {
+        $collection = new DoctrineBridgeCollection($this->createMock(Collection::class));
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('#is not an instance of ".+Selectable"#');
+
+        $collection->filter(Criteria::create());
     }
 
     /**

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -253,6 +253,37 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function sql_wildcards_in_value_are_literal(): void
+    {
+        $this->setupEntityManager();
+
+        foreach (['50% off', 'value_1', 'value 1', 'wild!card'] as $value) {
+            $this->em->persist(new Entity($value));
+        }
+
+        $this->flushAndClear();
+
+        $repo = $this->repo();
+
+        $results = $repo->filter(Spec::contains('value', '50%'));
+        $this->assertCount(1, $results);
+        $this->assertSame('50% off', $results->first()->value);
+
+        $results = $repo->filter(Spec::contains('value', 'value_1'));
+        $this->assertCount(1, $results);
+        $this->assertSame('value_1', $results->first()->value);
+
+        $results = $repo->filter(Spec::contains('value', 'wild!card'));
+        $this->assertCount(1, $results);
+        $this->assertSame('wild!card', $results->first()->value);
+
+        $this->assertCount(0, $repo->filter(Spec::startsWith('value', '%')));
+        $this->assertCount(0, $repo->filter(Spec::endsWith('value', '_')));
+    }
+
+    /**
+     * @test
+     */
     public function readonly_specification(): void
     {
         $results = $this->createWithItems(3)->filter(DoctrineSpec::readonly());

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -253,6 +253,20 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function callback_specification_receives_the_query_builder(): void
+    {
+        $repo = $this->createWithItems(3);
+
+        $results = $repo->filter(Spec::callback(
+            static fn(QueryBuilder $qb, string $alias) => $qb->andWhere("{$alias}.id < 3"),
+        ));
+
+        $this->assertCount(2, $results);
+    }
+
+    /**
+     * @test
+     */
     public function sql_wildcards_in_value_are_literal(): void
     {
         $this->setupEntityManager();

--- a/tests/Doctrine/ORM/Result/ObjectResultTest.php
+++ b/tests/Doctrine/ORM/Result/ObjectResultTest.php
@@ -117,6 +117,34 @@ class ObjectResultTest extends EntityResultTest
     /**
      * @test
      */
+    public function can_set_as_readonly_when_iterating(): void
+    {
+        $entities = \iterator_to_array($this->createWithItems(2)->readonly());
+
+        $this->assertCount(2, $entities);
+
+        foreach ($entities as $entity) {
+            $this->assertFalse($this->em->contains($entity));
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function can_set_as_readonly_when_paginating(): void
+    {
+        $entities = \iterator_to_array($this->createWithItems(2)->readonly()->paginate());
+
+        $this->assertCount(2, $entities);
+
+        foreach ($entities as $entity) {
+            $this->assertFalse($this->em->contains($entity));
+        }
+    }
+
+    /**
+     * @test
+     */
     public function can_use_criteria_as_filter_specification(): void
     {
         $collection = $this->createWithItems(10);

--- a/tests/Doctrine/ORM/Result/ObjectResultTest.php
+++ b/tests/Doctrine/ORM/Result/ObjectResultTest.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Collections\Criteria;
 use Zenstruck\Collection\Doctrine\Batch\CountableBatchIterator;
 use Zenstruck\Collection\Doctrine\Batch\CountableBatchProcessor;
 use Zenstruck\Collection\Doctrine\ORM\EntityResult;
+use Zenstruck\Collection\Spec;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\ORM\EntityResultTest;
 use Zenstruck\Collection\Tests\MatchableObjectTests;
@@ -112,6 +113,18 @@ class ObjectResultTest extends EntityResultTest
         $entity = $this->createWithItems(1)->readonly()->first();
 
         $this->assertFalse($this->em->contains($entity));
+    }
+
+    /**
+     * @test
+     */
+    public function count_is_not_cached_across_derived_results(): void
+    {
+        $result = $this->createWithItems(5);
+
+        $this->assertCount(5, $result);
+        $this->assertCount(2, $result->filter(Spec::lt('id', 3)));
+        $this->assertCount(5, $result);
     }
 
     /**


### PR DESCRIPTION
Fixes the bugs found while writing the README (#3), each with tests that fail without the fix.

- **`readonly()` was a no-op when iterating an `EntityResult`.** `getIterator()` applied only the result modifier, not `normalizeResult()` - so entities were detached via `first()`/`take()`/`eager()` but not via `foreach`.
- **`LIKE` values weren't escaped.** `str_replace('%', '%%')` isn't SQL escaping: the value is a bound parameter, so `%` and `_` reached the database as wildcards (`Spec::contains('value', '%')` matched every row). They're now escaped with an `ESCAPE` clause, leaving `*` as the only wildcard.
- **`DoctrineBridgeCollection::filter()` checked the wrong variable** (`$this->inner instanceof Criteria` rather than `$specification`), making the `LogicException` unreachable and surfacing a confusing `InvalidSpecification` instead.
- **`EntityResult::count()` memoization survived cloning**, so every derived result inherited the original's count.
- **`CriteriaInterpreter` didn't guard the `Spec::callback()` return value.** Returning the `Criteria` (as `andWhere()` does) violated `transform()`'s own return type. The callback may now either modify the `Criteria` or return an `Expression`; both are tested. This also adds the first coverage for `Spec::callback()`.

The last commit documents the behavior these change.

Note: making `_` literal is technically a behavior change for anyone relying on it as a single-character wildcard - it was undocumented and almost certainly unintended.
