### PR TITLE
fix: issues found in a full package audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,11 @@ foreach (Batch::process($posts, $em) as $post) {
 > `Batch::iterate()` never flushes. Changes you make to an entity while iterating are silently discarded when
 > the chunk is cleared - use `Batch::process()` if you intend to write.
 
+> [!IMPORTANT]
+> `Batch::process()` opens _one_ transaction for the whole loop, not one per chunk. Nothing is left half-done
+> if it fails, but the transaction is held for the entire run - worth keeping in mind when processing very
+> large sets, where it means long-lived locks.
+
 Both take a chunk size, defaulting to `100`:
 
 ```php

--- a/src/Collection/ArrayCollection.php
+++ b/src/Collection/ArrayCollection.php
@@ -116,7 +116,11 @@ final class ArrayCollection implements Collection
 
     public function first(mixed $default = null): mixed
     {
-        return $this->source[\array_key_first($this->source) ?? ''] ?? $default;
+        if (null === $key = \array_key_first($this->source)) {
+            return $default;
+        }
+
+        return $this->source[$key];
     }
 
     /**

--- a/src/Collection/Doctrine/ORM/EntityResult.php
+++ b/src/Collection/Doctrine/ORM/EntityResult.php
@@ -93,13 +93,9 @@ final class EntityResult implements Result
     public function first(mixed $default = null): mixed
     {
         $query = $this->query();
-        $sql = $query->getSQL();
 
-        if (\is_array($sql)) {
-            $sql = \implode(' ', $sql);
-        }
-
-        if (\str_starts_with(\mb_strtolower($sql), 'delete')) {
+        // check the DQL, not the SQL - the latter compiles the query, which setMaxResults() below invalidates
+        if (\str_starts_with(\mb_strtoupper($query->getDQL() ?? ''), 'DELETE')) {
             return $this->normalizeResult($query->execute());
         }
 

--- a/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
+++ b/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
@@ -110,7 +110,8 @@ final class QueryBuilderInterpreter
 
             OrderBy::class => $this->qb->addOrderBy($this->prefix($specification->field), $specification->direction),
 
-            Instance::class => $this->qb->expr()->isInstanceOf($this->alias, $this->param($specification->of())),
+            // the class name must be inlined - as a parameter it is used as the discriminator value verbatim
+            Instance::class => $this->qb->expr()->isInstanceOf($this->alias, $specification->of()),
             Delete::class => $this->qb->delete(),
             Unwritable::class => $this->qb->readonly(),
             Cache::class => $this->qb->cacheResult($specification->lifetime(), $specification->key()),

--- a/src/Collection/Page.php
+++ b/src/Collection/Page.php
@@ -31,6 +31,9 @@ final class Page implements \IteratorAggregate, \Countable
     private int $limit;
     private bool $strict = false;
 
+    /** @var non-negative-int */
+    private int $totalCount;
+
     /** @var Collection<V,K> */
     private Collection $cachedPage;
 
@@ -97,7 +100,7 @@ final class Page implements \IteratorAggregate, \Countable
 
     public function totalCount(): int
     {
-        return $this->collection->count();
+        return $this->totalCount ??= $this->collection->count();
     }
 
     public function getIterator(): \Traversable

--- a/src/Collection/Pages.php
+++ b/src/Collection/Pages.php
@@ -45,18 +45,14 @@ final class Pages implements \IteratorAggregate, \Countable
 
     public function getIterator(): \Traversable
     {
-        if (0 === $this->count()) {
-            return;
-        }
-
-        for ($page = 1; $page <= $this->count(); ++$page) {
+        for ($page = 1, $count = $this->count(); $page <= $count; ++$page) {
             yield $this->get($page);
         }
     }
 
     public function count(): int
     {
-        if (0 === $this->page1()->count()) {
+        if (0 === $this->page1()->totalCount()) {
             return 0;
         }
 

--- a/tests/ArrayCollectionTest.php
+++ b/tests/ArrayCollectionTest.php
@@ -197,6 +197,15 @@ final class ArrayCollectionTest extends TestCase
     /**
      * @test
      */
+    public function first_null_value_is_not_the_default(): void
+    {
+        $this->assertNull(Arr::for([null, 'a'])->first('default'));
+        $this->assertSame('default', Arr::for([])->first('default'));
+    }
+
+    /**
+     * @test
+     */
     public function group_by(): void
     {
         $arr = Arr::for(

--- a/tests/Doctrine/Fixture/Circle.php
+++ b/tests/Doctrine/Fixture/Circle.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Doctrine\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[ORM\Entity]
+class Circle extends Shape
+{
+}

--- a/tests/Doctrine/Fixture/Shape.php
+++ b/tests/Doctrine/Fixture/Shape.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Doctrine\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'shapes')]
+#[ORM\InheritanceType('SINGLE_TABLE')]
+#[ORM\DiscriminatorColumn(name: 'type', type: 'string')]
+#[ORM\DiscriminatorMap(['circle' => Circle::class, 'square' => Square::class])]
+abstract class Shape
+{
+    #[ORM\Id]
+    #[ORM\Column]
+    #[ORM\GeneratedValue]
+    public ?int $id = null;
+
+    public function __construct(#[ORM\Column] public string $name)
+    {
+    }
+}

--- a/tests/Doctrine/Fixture/Square.php
+++ b/tests/Doctrine/Fixture/Square.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Doctrine\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[ORM\Entity]
+class Square extends Shape
+{
+}

--- a/tests/Doctrine/HasDatabase.php
+++ b/tests/Doctrine/HasDatabase.php
@@ -20,6 +20,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Relation;
+use Zenstruck\Collection\Tests\Doctrine\Fixture\Shape;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -52,6 +53,7 @@ trait HasDatabase
         $schemaTool->createSchema([
             $this->em->getClassMetadata(Entity::class),
             $this->em->getClassMetadata(Relation::class),
+            $this->em->getClassMetadata(Shape::class),
         ]);
     }
 

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -319,6 +319,22 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function cache_specification(): void
+    {
+        $this->em->getConfiguration()->setResultCache(new ArrayAdapter());
+
+        $repo = $this->createWithItems(3);
+
+        $this->assertCount(3, $repo->filter(DoctrineSpec::cache(60, 'my-key'))->eager());
+
+        $this->assertQueryCount(0, function() use ($repo) {
+            $this->assertCount(3, $repo->filter(DoctrineSpec::cache(60, 'my-key'))->eager());
+        });
+    }
+
+    /**
+     * @test
+     */
     public function readonly_specification(): void
     {
         $results = $this->createWithItems(3)->filter(DoctrineSpec::readonly());

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Collection\Tests\Doctrine\ORM;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Zenstruck\Collection\Doctrine\Batch\CountableBatchIterator;
 use Zenstruck\Collection\Doctrine\DoctrineSpec;
 use Zenstruck\Collection\Doctrine\ObjectRepository;
@@ -22,8 +23,11 @@ use Zenstruck\Collection\Doctrine\ORM\Specification\Join;
 use Zenstruck\Collection\Exception\InvalidSpecification;
 use Zenstruck\Collection\Spec;
 use Zenstruck\Collection\Tests\CountableIteratorTests;
+use Zenstruck\Collection\Tests\Doctrine\Fixture\Circle;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Relation;
+use Zenstruck\Collection\Tests\Doctrine\Fixture\Shape;
+use Zenstruck\Collection\Tests\Doctrine\Fixture\Square;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 use Zenstruck\Collection\Tests\MatchableObjectTests;
 
@@ -293,6 +297,23 @@ class EntityRepositoryTest extends TestCase
 
         $this->assertCount(0, $repo->filter(Spec::startsWith('value', '%')));
         $this->assertCount(0, $repo->filter(Spec::endsWith('value', '_')));
+    }
+
+    /**
+     * @test
+     */
+    public function instance_of_specification(): void
+    {
+        $this->em->persist(new Circle('c1'));
+        $this->em->persist(new Circle('c2'));
+        $this->em->persist(new Square('s1'));
+        $this->flushAndClear();
+
+        $shapes = new EntityRepository($this->em, Shape::class);
+
+        $this->assertCount(3, $shapes);
+        $this->assertCount(2, $shapes->filter(DoctrineSpec::instanceOf(Circle::class)));
+        $this->assertCount(1, $shapes->filter(DoctrineSpec::instanceOf(Square::class)));
     }
 
     /**

--- a/tests/Doctrine/ORM/EntityResultQueryBuilderTest.php
+++ b/tests/Doctrine/ORM/EntityResultQueryBuilderTest.php
@@ -9,9 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Doctrine\ORM;
+namespace Zenstruck\Collection\Tests\Doctrine\ORM;
 
+use Doctrine\ORM\Query;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Zenstruck\Collection\Doctrine\ORM\EntityResultQueryBuilder;
 use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
 use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
@@ -22,6 +24,41 @@ use Zenstruck\Collection\Tests\Doctrine\HasDatabase;
 final class EntityResultQueryBuilderTest extends TestCase
 {
     use HasDatabase;
+
+    /**
+     * @test
+     */
+    public function can_modify_the_query(): void
+    {
+        $this->persistEntities(3);
+
+        $result = EntityResultQueryBuilder::forEntity($this->em, Entity::class, 'e')
+            ->modifyQuery(static fn(Query $query) => $query->setMaxResults(2))
+            ->result()
+        ;
+
+        $this->assertCount(2, $result->eager());
+    }
+
+    /**
+     * @test
+     */
+    public function can_cache_the_result(): void
+    {
+        $this->em->getConfiguration()->setResultCache(new ArrayAdapter());
+        $this->persistEntities(3);
+
+        $result = EntityResultQueryBuilder::forEntity($this->em, Entity::class, 'e')
+            ->cacheResult(60, 'my-key')
+            ->result()
+        ;
+
+        $this->assertCount(3, $result->eager());
+
+        $this->assertQueryCount(0, function() use ($result) {
+            $this->assertCount(3, $result->eager());
+        });
+    }
 
     /**
      * @test

--- a/tests/Doctrine/ORM/Result/SingleScalarTest.php
+++ b/tests/Doctrine/ORM/Result/SingleScalarTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Doctrine\ORM\Result;
+namespace Zenstruck\Collection\Tests\Doctrine\ORM\Result;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Collection\Doctrine\ORM\EntityResultQueryBuilder;

--- a/tests/PagesTest.php
+++ b/tests/PagesTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Collection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\CallbackCollection;
 use Zenstruck\Collection\LazyCollection;
 use Zenstruck\Collection\Pages;
 
@@ -20,6 +21,46 @@ use Zenstruck\Collection\Pages;
  */
 final class PagesTest extends TestCase
 {
+    /**
+     * @test
+     */
+    public function counting_does_not_load_the_first_page(): void
+    {
+        $iterations = 0;
+        $collection = new CallbackCollection(
+            static function() use (&$iterations) {
+                ++$iterations;
+
+                yield from \range(1, 10);
+            },
+            static fn() => 10,
+        );
+
+        $this->assertCount(4, new Pages($collection, 3));
+        $this->assertSame(0, $iterations);
+    }
+
+    /**
+     * @test
+     */
+    public function iterating_only_counts_the_collection_once(): void
+    {
+        $counts = 0;
+        $collection = new CallbackCollection(
+            static fn() => yield from \range(1, 10),
+            static function() use (&$counts) {
+                ++$counts;
+
+                return 10;
+            },
+        );
+
+        $pages = new Pages($collection, 3);
+
+        $this->assertCount(4, \iterator_to_array($pages));
+        $this->assertSame(1, $counts);
+    }
+
     /**
      * @test
      */

--- a/tests/Specification/UtilTest.php
+++ b/tests/Specification/UtilTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Specification;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\Spec;
+use Zenstruck\Collection\Specification\Filter\Between;
+use Zenstruck\Collection\Specification\Nested;
+use Zenstruck\Collection\Specification\Util;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class UtilTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function stringify_stringable_specifications(): void
+    {
+        $this->assertSame("Compare(name EqualTo 'kevin')", Util::stringify(Spec::eq('name', 'kevin')));
+        $this->assertSame('Compare(views GreaterThan 100)', Util::stringify(Spec::gt('views', 100)));
+        $this->assertSame('IsNull(deletedAt)', Util::stringify(Spec::isNull('deletedAt')));
+        $this->assertSame('OrderBy(name)', Util::stringify(Spec::sortAsc('name')));
+        $this->assertSame('Between[1 AND 5]', Util::stringify(Between::inclusive('id', 1, 5)));
+        $this->assertSame('Between(1 AND 5)', Util::stringify(Between::exclusive('id', 1, 5)));
+    }
+
+    /**
+     * @test
+     */
+    public function stringify_nested_specifications(): void
+    {
+        $this->assertSame(
+            \sprintf("%s(Compare(status EqualTo 'published'))", NestedFixture::class),
+            Util::stringify(new NestedFixture()),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function stringify_anything_else(): void
+    {
+        $this->assertSame('string', Util::stringify('foo'));
+        $this->assertSame('int', Util::stringify(1));
+        $this->assertSame('null', Util::stringify(null));
+        $this->assertSame(\stdClass::class, Util::stringify(new \stdClass()));
+    }
+}
+
+final class NestedFixture implements Nested
+{
+    public function specification(): mixed
+    {
+        return Spec::eq('status', 'published');
+    }
+}

--- a/tests/Symfony/Doctrine/ChainObjectRepositoryFactoryTest.php
+++ b/tests/Symfony/Doctrine/ChainObjectRepositoryFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Symfony\Doctrine;
+
+use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\Doctrine\ObjectRepository;
+use Zenstruck\Collection\Doctrine\ObjectRepositoryFactory;
+use Zenstruck\Collection\Symfony\Doctrine\ChainObjectRepositoryFactory;
+use Zenstruck\Collection\Tests\Doctrine\Fixture\Entity;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class ChainObjectRepositoryFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function repositories_are_cached_per_class(): void
+    {
+        $inner = $this->createMock(ObjectRepositoryFactory::class);
+        $inner->expects($this->once())
+            ->method('create')
+            ->with(Entity::class)
+            ->willReturn($this->createMock(ObjectRepository::class))
+        ;
+
+        $factory = new ChainObjectRepositoryFactory($inner);
+
+        $this->assertSame($factory->create(Entity::class), $factory->create(Entity::class));
+    }
+
+    /**
+     * @test
+     */
+    public function resetting_clears_the_cache(): void
+    {
+        $inner = $this->createMock(ObjectRepositoryFactory::class);
+        $inner->expects($this->exactly(2))
+            ->method('create')
+            ->willReturnCallback(fn() => $this->createMock(ObjectRepository::class))
+        ;
+
+        $factory = new ChainObjectRepositoryFactory($inner);
+        $first = $factory->create(Entity::class);
+
+        $factory->reset();
+
+        $this->assertNotSame($first, $factory->create(Entity::class));
+    }
+}


### PR DESCRIPTION
Findings from a full audit of the package (grid excluded), one commit each.

- **`Pages` counted more than it needed to.** `count()` loaded the first page's items just to test for emptiness, and `getIterator()` re-counted on every iteration - for a collection that counts by iterating, that made paging over it O(n × pages). `Page::totalCount()` is now memoized too.
- **`ArrayCollection::first()` returned the default for a `null` first item**, unable to distinguish it from an empty collection - unlike every other implementation.
- **`first()` compiled the query twice.** It called `getSQL()` to check for a delete, then invalidated that compilation with `setMaxResults()`. It now checks the DQL, which is already built.
- **`DoctrineSpec::instanceOf()` never matched anything.** The class name was bound as a parameter, so Doctrine compared the discriminator column to the FQCN (`s0_.type IN ('App\Entity\Circle')`). DQL needs it inlined. Single-table-inheritance fixtures were added to cover it.
- **Coverage for previously untested features**: `Util::stringify()`, `EntityResultQueryBuilder::modifyQuery()`/`cacheResult()`, the `cache` specification, and `ChainObjectRepositoryFactory::reset()`. Also corrects the namespace of two test classes, which weren't PSR-4 autoloadable.
- **Documents** that `Batch::process()` uses a single transaction for the whole loop rather than one per chunk.
