### PR TITLE
fix: nested join aliases, add a Spec::between() factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,7 +999,7 @@ $posts->filter(Spec::andX(
 | `Spec::contains($field, $value)`            | Matches when `$field` contains `$value`            |
 | `Spec::startsWith($field, $value)`          | Matches when `$field` starts with `$value`         |
 | `Spec::endsWith($field, $value)`            | Matches when `$field` ends with `$value`           |
-| `Between::inclusive($field, $begin, $end)`  | Matches when `$begin <= $field <= $end`            |
+| `Spec::between($field, $begin, $end)`       | Matches when `$begin <= $field <= $end`            |
 | `Spec::andX(...$specs)`                     | Matches when every `$spec` matches                 |
 | `Spec::orX(...$specs)`                      | Matches when at least one `$spec` matches          |
 | `Spec::not($spec)`                          | Matches when `$spec` does not match                |
@@ -1008,15 +1008,14 @@ $posts->filter(Spec::andX(
 | `Spec::callback($callable)`                 | Drops down to the underlying query object          |
 
 > [!NOTE]
-> `Between` is the one filter without a `Spec` factory method - construct it directly. Both bounds are
-> included unless you say otherwise:
+> Both `between()` bounds are included unless you say otherwise:
 > ```php
 > use Zenstruck\Collection\Specification\Filter\Between;
 >
-> Between::inclusive('publishedAt', $start, $end);                     // both included
-> Between::exclusive('publishedAt', $start, $end);                     // both excluded
-> new Between('publishedAt', $start, $end, Between::INCLUSIVE_BEGIN);  // begin included, end excluded
-> new Between('publishedAt', $start, $end, Between::EXCLUSIVE_BEGIN);  // begin excluded, end included
+> Spec::between('publishedAt', $start, $end);                           // both included
+> Spec::between('publishedAt', $start, $end, Between::EXCLUSIVE);       // both excluded
+> Spec::between('publishedAt', $start, $end, Between::INCLUSIVE_BEGIN); // begin included, end excluded
+> Spec::between('publishedAt', $start, $end, Between::EXCLUSIVE_BEGIN); // begin excluded, end included
 > ```
 
 #### String Wildcards

--- a/src/Collection/Doctrine/ORM/Specification/Join.php
+++ b/src/Collection/Doctrine/ORM/Specification/Join.php
@@ -21,18 +21,15 @@ final class Join extends Field
     private const TYPE_INNER = 'inner';
     private const TYPE_LEFT = 'left';
 
-    private string $alias;
     private bool $eager = false;
     private mixed $child = null;
 
     /**
      * @param self::TYPE_INNER|self::TYPE_LEFT $type
      */
-    private function __construct(private string $type, string $field, ?string $alias = null)
+    private function __construct(private string $type, string $field, private ?string $alias = null)
     {
         parent::__construct($field);
-
-        $this->alias = $alias ?? $field;
     }
 
     public function __toString(): string
@@ -71,7 +68,15 @@ final class Join extends Field
 
     public function alias(): string
     {
-        return $this->alias;
+        return $this->alias ?? $this->field;
+    }
+
+    /**
+     * @internal
+     */
+    public function hasExplicitAlias(): bool
+    {
+        return null !== $this->alias;
     }
 
     /**

--- a/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
+++ b/src/Collection/Doctrine/ORM/Specification/QueryBuilderInterpreter.php
@@ -114,7 +114,7 @@ final class QueryBuilderInterpreter
             Delete::class => $this->qb->delete(),
             Unwritable::class => $this->qb->readonly(),
             Cache::class => $this->qb->cacheResult($specification->lifetime(), $specification->key()),
-            AntiJoin::class => $this->qb->leftJoin($this->prefix($specification->field), $specification->field)->andWhere($this->qb->expr()->isNull($specification->field)),
+            AntiJoin::class => $this->interpretAntiJoin($specification),
             Join::class => $this->interpretJoin($specification),
 
             default => throw InvalidSpecification::build($specification, $this->callingClass, $this->callingMethod),
@@ -134,12 +134,21 @@ final class QueryBuilderInterpreter
         return $this->transform($between->asAnd());
     }
 
+    private function interpretAntiJoin(AntiJoin $join): mixed
+    {
+        $alias = $this->joinAlias($join->field);
+
+        $this->qb->leftJoin($this->prefix($join->field), $alias);
+
+        return $this->qb->expr()->isNull($alias);
+    }
+
     private function interpretJoin(Join $join): mixed
     {
-        $this->addJoinToQueryBuilder($join);
+        $alias = $this->addJoinToQueryBuilder($join);
 
         if ($join->isEager()) {
-            $this->qb->addSelect($join->alias());
+            $this->qb->addSelect($alias);
         }
 
         if (null === $join->child()) {
@@ -147,25 +156,42 @@ final class QueryBuilderInterpreter
         }
 
         $interpreter = clone $this;
-        $interpreter->alias = $join->alias();
+        $interpreter->alias = $alias;
 
         return $interpreter->transform($join->child());
     }
 
-    private function addJoinToQueryBuilder(Join $join): void
+    private function addJoinToQueryBuilder(Join $join): string
     {
         $field = $this->prefix($join->field);
 
         foreach ($this->qb->getDQLParts()['join'] as $entry) {
             foreach ($entry as $item) {
                 if ($field === $item->getJoin()) {
-                    // join already added
-                    return;
+                    // join already added - reuse its alias
+                    return $item->getAlias();
                 }
             }
         }
 
-        $this->qb->{$join->type().'Join'}($field, $join->alias());
+        $alias = $this->joinAlias($join->alias(), $join->hasExplicitAlias());
+
+        $this->qb->{$join->type().'Join'}($field, $alias);
+
+        return $alias;
+    }
+
+    /**
+     * Qualifies the alias of a nested join with its parent's so that relations
+     * with the same name on different parents don't collide.
+     */
+    private function joinAlias(string $alias, bool $explicit = false): string
+    {
+        if ($explicit || $this->alias === ($this->qb->getRootAliases()[0] ?? $this->alias)) {
+            return $alias;
+        }
+
+        return \sprintf('%s_%s', $this->alias, $alias);
     }
 
     private function composite(Composite $specification, string $method): DoctrineComposite|Func|null

--- a/src/Collection/Spec.php
+++ b/src/Collection/Spec.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Collection;
 
 use Zenstruck\Collection\Specification\Callback;
+use Zenstruck\Collection\Specification\Filter\Between;
 use Zenstruck\Collection\Specification\Filter\Contains;
 use Zenstruck\Collection\Specification\Filter\EndsWith;
 use Zenstruck\Collection\Specification\Filter\EqualTo;
@@ -54,6 +55,14 @@ class Spec
     final public static function eq(string $field, mixed $value): EqualTo
     {
         return new EqualTo($field, $value);
+    }
+
+    /**
+     * @param Between::* $type
+     */
+    final public static function between(string $field, mixed $begin, mixed $end, string $type = Between::INCLUSIVE): Between
+    {
+        return new Between($field, $begin, $end, $type);
     }
 
     final public static function contains(string $field, string $value): Contains

--- a/src/Collection/Specification/Util.php
+++ b/src/Collection/Specification/Util.php
@@ -21,7 +21,7 @@ final class Util
     public static function stringify(mixed $specification): string
     {
         if ($specification instanceof \Stringable) {
-            return $specification;
+            return (string) $specification;
         }
 
         if ($specification instanceof Nested) {

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -452,6 +452,53 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function filter_with_anti_join_within_a_composite(): void
+    {
+        $this->persistEntitiesForJoinTest();
+
+        $results = $this->repo()->filter(Spec::orX(
+            Join::anti('relation'),
+            Spec::eq('value', 'e3'),
+        ));
+
+        $this->assertCount(3, $results);
+    }
+
+    /**
+     * @test
+     */
+    public function nested_joins_of_the_same_relation_do_not_collide(): void
+    {
+        $this->persistEntitiesForJoinTest();
+
+        $results = $this->repo()->filter(
+            Join::inner('relation')->scope(Join::inner('entities')->scope(Join::inner('relation'))),
+        );
+
+        $this->assertCount(3, $results);
+    }
+
+    /**
+     * @test
+     */
+    public function an_explicit_join_alias_is_never_qualified(): void
+    {
+        $this->persistEntitiesForJoinTest();
+
+        $results = $this->repo()->filter(
+            Join::inner('relation')->scope(
+                Join::inner('entities', 'e2')->scope(Spec::callback(
+                    static fn(QueryBuilder $qb) => $qb->andWhere('e2.value = :value')->setParameter('value', 'e3'),
+                )),
+            ),
+        );
+
+        $this->assertCount(1, $results);
+    }
+
+    /**
+     * @test
+     */
     public function filter_with_join_and_multiple_scope(): void
     {
         $this->persistEntitiesForJoinTest();

--- a/tests/MatchableObjectTests.php
+++ b/tests/MatchableObjectTests.php
@@ -333,6 +333,10 @@ trait MatchableObjectTests
         $this->assertSame(2, $r->first()->id);
         $this->assertCount(1, $r = $repo->filter(Between::exclusive('id', 2, 4)));
         $this->assertSame(3, $r->first()->id);
+        $this->assertCount(3, $r = $repo->filter(Spec::between('id', 2, 4)));
+        $this->assertSame(2, $r->first()->id);
+        $this->assertCount(1, $r = $repo->filter(Spec::between('id', 2, 4, Between::EXCLUSIVE)));
+        $this->assertSame(3, $r->first()->id);
     }
 
     abstract protected function createWithItems(int $count): Matchable;


### PR DESCRIPTION
Three unrelated issues found in the audit, one commit each.

- **Nested join aliases collided.** A nested join defaulted its alias to the relation name, so `Join::inner('relation')->scope(Join::inner('entities')->scope(Join::inner('relation')))` failed with `[Semantical Error] ... 'relation' is already defined`. Nested aliases are now prefixed with their parent's (`relation_entities`, `relation_entities_relation`); an explicit alias is never touched. While in there, an anti-join now returns its expression instead of calling `andWhere()` itself, so it composes correctly inside `orX()` - previously it was applied unconditionally.
- **`Util::stringify()` returned a `Stringable`** from a method declared `: string`. Harmless today only because this package doesn't declare strict types.
- **Added `Spec::between()`**, so `Between` is no longer the only filter you have to construct directly. README updated.
