### PR TITLE
feat: paginate without counting the collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,10 @@ foreach ($titles as $title) {
 | Method                                    | Runs the source?                       | How much it reads                     |
 |-------------------------------------------|----------------------------------------|---------------------------------------|
 | `filter()`, `map()`, `keyBy()`, `take()`  | No - returns a new lazy collection     | Nothing                               |
+| `paginate()`, `pages()`                   | No - returns a `Page`/`Pages`          | Nothing                               |
 | `first()`                                 | Yes                                    | Stops at the first item               |
 | `find()`                                  | Yes                                    | Stops at the first match              |
+| `Page::hasMorePages()`                    | Yes                                    | One item past the end of the page     |
 | `count()`, `isEmpty()`                    | Only if the source isn't `Countable`   | Counts, keeping nothing               |
 | `reduce()`                                | Yes                                    | All of it, keeping nothing            |
 | `eager()`                                 | Yes                                    | All of it, kept in memory             |
@@ -325,38 +327,102 @@ foreach ($page as $post) {
 }
 ```
 
+What it costs depends on how much of that metadata you use:
+
+| Mode              | Renders                              | Counts the collection? |
+|-------------------|--------------------------------------|------------------------|
+| [Simple](#simple) | Previous / Next                      | no                     |
+| [Full](#full)     | "Page 2 of 7", numbered links, Last  | yes, once              |
+
+There's only one `Page` - you don't choose a mode up front, you get one by what your template asks for.
+
+> [!NOTE]
+> "Counts the collection" means calling `count()` on the source, and what that costs is up to the source: it's
+> free for an array, a `SELECT COUNT(...)` for [Doctrine](#doctrine), and a full iteration for a generator or
+> an API-backed [`LazyCollection`](#lazycollection) - see [Lazy vs Eager](#lazy-vs-eager).
+
+### Simple
+
+Everything a previous/next pager needs comes from the page itself, without counting anything:
+
+```php
+$page = $posts->paginate(page: 2, limit: 20); // takes 21 items, starting at 20
+
+$page->currentPage();    // 2
+\count($page);           // 20
+$page->hasMorePages();   // true
+$page->nextPage();       // 3
+$page->previousPage();   // 1
+$page->haveToPaginate(); // true
+
+foreach ($page as $post) {
+    // ...
+}
+```
+
+Note the 21 items for a page of 20. Knowing whether another page exists doesn't require counting the
+collection - the page reads one item more than fits on it, and the presence of that extra item _is_ the
+answer. It's dropped before you see the items, which is why `count($page)` is still 20.
+
+That one item is often the difference between a bounded amount of work and an unbounded one. Paging an
+[API-backed collection](#lazycollection) this way reads a single page's worth of results; asking it for a
+total would walk every page the API has.
+
 The items are fetched once and cached, so iterating the same `Page` more than once won't re-run the source.
 
-| Method                          | Description                                                        |
-|---------------------------------|--------------------------------------------------------------------|
-| `currentPage()`                 | The current page number                                            |
-| `limit()`                       | Items per page                                                     |
-| `count()`                       | Number of items on _this_ page                                     |
-| `totalCount()`                  | Number of items in the entire collection                           |
-| `firstPage()`                   | Always `1`                                                         |
-| `lastPage()` / `pageCount()`    | The last page number (`1` when empty)                              |
-| `nextPage()` / `previousPage()` | The adjacent page number, or `null` at the boundary                |
-| `haveToPaginate()`              | Whether there is more than one page                                |
+> [!NOTE]
+> Ask for a page past the end and you get an empty one: `hasMorePages()` and `nextPage()` report nothing
+> follows, `previousPage()` still works. See [Strict Mode](#strict-mode) to fall back to the last page
+> instead.
+
+### Full
+
+Rendering "Page 2 of 7", numbered links or a "Last" link needs the total, so these count the collection -
+the first time you ask, and once:
+
+```php
+$page->totalCount(); // 138
+$page->lastPage();   // 7
+$page->pageCount();  // 7
+$page->firstPage();  // 1
+```
+
+| Method                          | Description                                                        | Counts? |
+|---------------------------------|--------------------------------------------------------------------|---------|
+| `currentPage()`                 | The current page number                                            | no      |
+| `limit()`                       | Items per page                                                     | no      |
+| `count()`                       | Number of items on _this_ page                                     | no      |
+| `firstPage()`                   | Always `1`                                                         | no      |
+| `hasMorePages()`                | Whether another page follows this one                              | no      |
+| `nextPage()` / `previousPage()` | The adjacent page number, or `null` at the boundary                | no      |
+| `haveToPaginate()`              | Whether there is more than one page                                | no      |
+| `totalCount()`                  | Number of items in the entire collection                           | **yes** |
+| `lastPage()` / `pageCount()`    | The last page number (`1` when empty)                              | **yes** |
 
 > [!NOTE]
 > Out of range arguments are normalized rather than rejected: a page less than `1` becomes `1` and a limit
 > less than `1` becomes the default (`20`).
 
-### Strict Mode
+#### Strict Mode
 
-By default, `currentPage()` returns whatever page you asked for, even if it's past the end. Enable strict mode
-to clamp it to the last page instead:
+A page number from a bookmark or a hand-edited URL can point past the end of the collection - and a filter
+that shrank the result set can do the same to a page number that used to be valid. Strict mode falls back to
+the last page when that happens:
 
 ```php
-$page = $posts->paginate(page: 999)->strict();
+$page = $posts->paginate(page: 999, limit: 20)->strict();
 
-$page->currentPage(); // 4 (the last page) instead of 999
+$page->currentPage(); // 7 - the last page, not 999
+\count($page);        // 18 - and these are the last page's items
 ```
 
-> [!IMPORTANT]
-> Strict mode is worth it when the page number comes from user input and you don't want an empty page for
-> `?page=999`. The tradeoff is that determining the last page requires counting the collection - an extra
-> query for Doctrine sources.
+This is free here: the total is already known, so clamping costs nothing extra. The fallback only re-fetches
+when the requested page really was out of range.
+
+> [!TIP]
+> `strict()` works on a [Simple](#simple) page too, but it gives up the no-counting guarantee: clamping needs
+> the total. An in-range page still counts nothing, but an out of range one reads the empty page, counts, then
+> reads the last page. Keep `strict()` to Full pagers if that matters.
 
 ### Iterating Pages
 
@@ -448,6 +514,19 @@ $result->isEmpty();
 foreach ($result as $post) {
     // ...
 }
+```
+
+This is where [pagination's counting](#pagination) shows up as real queries. A previous/next pager is a single
+query; adding a total makes it two:
+
+```php
+$page = $result->paginate(page: 2, limit: 20);
+
+$page->hasMorePages(); // SELECT ... LIMIT 21 OFFSET 20
+$page->nextPage();     // (already fetched)
+
+$page->totalCount();   // SELECT COUNT(...)
+$page->lastPage();     // (already counted)
 ```
 
 Because it's immutable, deriving is free and the original stays usable:

--- a/README.md
+++ b/README.md
@@ -424,6 +424,54 @@ when the requested page really was out of range.
 > the total. An in-range page still counts nothing, but an out of range one reads the empty page, counts, then
 > reads the last page. Keep `strict()` to Full pagers if that matters.
 
+### Templating
+
+Two pager templates are bundled, matching the two modes. Both take the `Page` and link to the current route,
+keeping whatever query parameters are already there:
+
+```twig
+{# previous/next - counts nothing #}
+{{ include('@ZenstruckCollection/Pager/_simple.html.twig', {page: page}) }}
+
+{# numbered - counts once #}
+{{ include('@ZenstruckCollection/Pager/_full.html.twig', {page: page}) }}
+```
+
+Neither renders anything at all when the collection fits on one page. The markup is unstyled and deliberately
+plain - copy it into your app and adjust rather than fighting it:
+
+```html
+<ul class="pager pager-simple">
+    <li><a href="/posts?page=2" rel="prev">Previous</a></li>
+    <li><a href="/posts?page=4" rel="next">Next</a></li>
+</ul>
+```
+
+Both accept the same options:
+
+| Variable | Description                                                                            |
+|----------|----------------------------------------------------------------------------------------|
+| `page`   | The `Page` to render (required)                                                         |
+| `route`  | The route to link to (defaults to the current one)                                      |
+| `params` | The route/query parameters to keep (defaults to the current request's)                 |
+| `key`    | The page query parameter (defaults to `page`)                                           |
+| `window` | `_full` only: how many pages to show either side of the current one (defaults to `4`)  |
+
+```twig
+{{ include('@ZenstruckCollection/Pager/_full.html.twig', {
+    page: page,
+    route: 'post_archive',
+    params: {year: 2026},
+    key: 'p',
+    window: 2,
+}) }}
+```
+
+> [!NOTE]
+> These require Twig and Symfony's routing (`path()`), and are registered by the
+> [bundle](#symfony-integration).
+
+
 ### Iterating Pages
 
 `pages()` returns a `Pages` object - a lazy, page-by-page view of the entire collection. Each page is a
@@ -1241,6 +1289,13 @@ return [
 
 There is nothing to configure. When DoctrineBundle is installed, the repository services below are registered
 automatically.
+
+The bundle also registers the `@ZenstruckCollection` Twig namespace, which is where the
+[pager templates](#templating) live:
+
+```twig
+{{ include('@ZenstruckCollection/Pager/_simple.html.twig', {page: page}) }}
+```
 
 ### A Repository For Any Entity
 

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/expression-language": "^6.4|^7.0|^8.0",
         "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "symfony/phpunit-bridge": "^6.3|^7.0|^8.0",
+        "symfony/twig-bundle": "^6.4|^7.0|^8.0",
         "symfony/var-dumper": "^6.4|^7.0|^8.0",
         "zenstruck/foundry": "^2.0",
         "zenstruck/uri": "^2.3"

--- a/src/Collection/Page.php
+++ b/src/Collection/Page.php
@@ -30,6 +30,7 @@ final class Page implements \IteratorAggregate, \Countable
     /** @var positive-int */
     private int $limit;
     private bool $strict = false;
+    private bool $hasMorePages;
 
     /** @var non-negative-int */
     private int $totalCount;
@@ -108,15 +109,24 @@ final class Page implements \IteratorAggregate, \Countable
         return $this->getPage()->getIterator();
     }
 
+    /**
+     * Whether there is at least one more page after this one. Unlike
+     * {@see lastPage}, this doesn't require counting the collection.
+     */
+    public function hasMorePages(): bool
+    {
+        $this->getPage();
+
+        return $this->hasMorePages;
+    }
+
     public function nextPage(): ?int
     {
-        $currentPage = $this->currentPage();
-
-        if ($currentPage === $this->lastPage()) {
+        if (!$this->hasMorePages()) {
             return null;
         }
 
-        return ++$currentPage;
+        return $this->currentPage() + 1;
     }
 
     public function previousPage(): ?int
@@ -159,10 +169,13 @@ final class Page implements \IteratorAggregate, \Countable
 
     public function haveToPaginate(): bool
     {
-        return $this->pageCount() > 1;
+        return $this->currentPage() > 1 || $this->hasMorePages();
     }
 
     /**
+     * Fetches one more item than fits on the page - its presence is what
+     * {@see hasMorePages} reports, and it's dropped before returning.
+     *
      * @return Collection<V,K>
      */
     private function getPage(): Collection
@@ -172,7 +185,9 @@ final class Page implements \IteratorAggregate, \Countable
         }
 
         $offset = $this->currentPage() * $this->limit() - $this->limit();
+        $items = $this->collection->take($this->limit() + 1, $offset)->eager();
+        $this->hasMorePages = $items->count() > $this->limit();
 
-        return $this->cachedPage = $this->collection->take($this->limit(), $offset);
+        return $this->cachedPage = $items->take($this->limit());
     }
 }

--- a/src/Collection/Page.php
+++ b/src/Collection/Page.php
@@ -32,6 +32,9 @@ final class Page implements \IteratorAggregate, \Countable
     private bool $strict = false;
     private bool $hasMorePages;
 
+    /** @var positive-int */
+    private int $resolvedPage;
+
     /** @var non-negative-int */
     private int $totalCount;
 
@@ -52,12 +55,12 @@ final class Page implements \IteratorAggregate, \Countable
     /**
      * Enable/Disable "strict mode".
      *
-     * When enabled, when calling {@see currentPage}, if provided page number
-     * greater than the calculated last page number, the last page number will
-     * be returned.
+     * When enabled, a page past the end of the collection falls back to the
+     * last page - {@see currentPage} reports it and the page's items are the
+     * last page's.
      *
-     * When enabled, extra work (ie count query) may be required to ensure the
-     * current page number is valid.
+     * The fallback is what requires counting the collection, so it's only
+     * paid for when the requested page really is out of range.
      *
      * @return $this
      */
@@ -74,13 +77,9 @@ final class Page implements \IteratorAggregate, \Countable
             return $this->page;
         }
 
-        $lastPage = $this->lastPage();
+        $this->resolve();
 
-        if ($this->page > $lastPage) {
-            return $lastPage;
-        }
-
-        return $this->page;
+        return $this->resolvedPage;
     }
 
     /**
@@ -173,21 +172,47 @@ final class Page implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Fetches one more item than fits on the page - its presence is what
-     * {@see hasMorePages} reports, and it's dropped before returning.
-     *
      * @return Collection<V,K>
      */
     private function getPage(): Collection
     {
+        $this->resolve();
+
+        return $this->cachedPage;
+    }
+
+    /**
+     * Fetches the page, falling back to the last page in strict mode if the
+     * requested one turned out to be past the end. Only that fallback needs
+     * the collection counted.
+     */
+    private function resolve(): void
+    {
         if (isset($this->cachedPage)) {
-            return $this->cachedPage;
+            return;
         }
 
-        $offset = $this->currentPage() * $this->limit() - $this->limit();
-        $items = $this->collection->take($this->limit() + 1, $offset)->eager();
-        $this->hasMorePages = $items->count() > $this->limit();
+        $items = $this->fetch($page = $this->page);
 
-        return $this->cachedPage = $items->take($this->limit());
+        if ($this->strict && $page > 1 && !$items->count()) {
+            $items = $this->fetch($page = $this->lastPage());
+        }
+
+        $this->resolvedPage = $page;
+        $this->hasMorePages = $items->count() > $this->limit();
+        $this->cachedPage = $items->take($this->limit());
+    }
+
+    /**
+     * Fetches one more item than fits on the page - its presence is what
+     * {@see hasMorePages} reports, and it's dropped by {@see resolve}.
+     *
+     * @param positive-int $page
+     *
+     * @return ArrayCollection<V,K&array-key>
+     */
+    private function fetch(int $page): ArrayCollection
+    {
+        return $this->collection->take($this->limit() + 1, $page * $this->limit() - $this->limit())->eager();
     }
 }

--- a/templates/Pager/_full.html.twig
+++ b/templates/Pager/_full.html.twig
@@ -1,0 +1,41 @@
+{#
+    A numbered pager for a Zenstruck\Collection\Page. Counts the collection (once) for the page count.
+
+    page:   the Page (required)
+    route:  the route to link to (defaults to the current one)
+    params: the route/query parameters to keep (defaults to the current request's)
+    key:    the page query parameter (defaults to "page")
+    window: how many pages to show on each side of the current one (defaults to 4)
+#}
+{% set key = key|default('page') %}
+{% set window = window|default(4) %}
+{% set route = route|default(app.request.attributes.get('_route')) %}
+{% set params = params|default(app.request.query.all|merge(app.request.attributes.get('_route_params')|default({}))) %}
+
+{% if page.haveToPaginate %}
+    <ul class="pager pager-full">
+        {% if page.previousPage %}
+            <li><a href="{{ path(route, params|merge({(key): page.previousPage})) }}" rel="prev">&lt;</a></li>
+        {% else %}
+            <li class="disabled"><span>&lt;</span></li>
+        {% endif %}
+
+        {% for i in page.firstPage..page.lastPage %}
+            {% if i == page.currentPage %}
+                <li class="active"><span>{{ i }}</span></li>
+            {% elseif i == page.firstPage or i == page.lastPage %}
+                <li><a href="{{ path(route, params|merge({(key): i})) }}">{{ i }}</a></li>
+            {% elseif i == page.currentPage - window or i == page.currentPage + window %}
+                <li class="disabled"><span>&hellip;</span></li>
+            {% elseif i > page.currentPage - window and i < page.currentPage + window %}
+                <li><a href="{{ path(route, params|merge({(key): i})) }}">{{ i }}</a></li>
+            {% endif %}
+        {% endfor %}
+
+        {% if page.nextPage %}
+            <li><a href="{{ path(route, params|merge({(key): page.nextPage})) }}" rel="next">&gt;</a></li>
+        {% else %}
+            <li class="disabled"><span>&gt;</span></li>
+        {% endif %}
+    </ul>
+{% endif %}

--- a/templates/Pager/_simple.html.twig
+++ b/templates/Pager/_simple.html.twig
@@ -1,0 +1,27 @@
+{#
+    A previous/next pager for a Zenstruck\Collection\Page. Renders without counting the collection.
+
+    page:  the Page (required)
+    route: the route to link to (defaults to the current one)
+    params: the route/query parameters to keep (defaults to the current request's)
+    key:   the page query parameter (defaults to "page")
+#}
+{% set key = key|default('page') %}
+{% set route = route|default(app.request.attributes.get('_route')) %}
+{% set params = params|default(app.request.query.all|merge(app.request.attributes.get('_route_params')|default({}))) %}
+
+{% if page.haveToPaginate %}
+    <ul class="pager pager-simple">
+        {% if page.previousPage %}
+            <li><a href="{{ path(route, params|merge({(key): page.previousPage})) }}" rel="prev">Previous</a></li>
+        {% else %}
+            <li class="disabled"><span>Previous</span></li>
+        {% endif %}
+
+        {% if page.nextPage %}
+            <li><a href="{{ path(route, params|merge({(key): page.nextPage})) }}" rel="next">Next</a></li>
+        {% else %}
+            <li class="disabled"><span>Next</span></li>
+        {% endif %}
+    </ul>
+{% endif %}

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -362,6 +362,29 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function strict_mode_only_counts_when_the_page_is_out_of_range(): void
+    {
+        $result = $this->createWithItems(10)->filter(null)->disableFetchJoins();
+
+        $this->assertQueryCount(1, function() use ($result) {
+            $page = $result->paginate(page: 2, limit: 3)->strict();
+
+            $this->assertSame(2, $page->currentPage());
+            $this->assertCount(3, $page);
+        });
+
+        // the empty fetch, the count to find the last page, then re-fetching it
+        $this->assertQueryCount(3, function() use ($result) {
+            $page = $result->paginate(page: 99, limit: 3)->strict();
+
+            $this->assertSame(4, $page->currentPage());
+            $this->assertCount(1, $page);
+        });
+    }
+
+    /**
+     * @test
+     */
     public function readonly_specification(): void
     {
         $results = $this->createWithItems(3)->filter(DoctrineSpec::readonly());

--- a/tests/Doctrine/ORM/EntityRepositoryTest.php
+++ b/tests/Doctrine/ORM/EntityRepositoryTest.php
@@ -335,6 +335,33 @@ class EntityRepositoryTest extends TestCase
     /**
      * @test
      */
+    public function paginating_does_not_execute_a_count_query(): void
+    {
+        $result = $this->createWithItems(10)->filter(null)->disableFetchJoins();
+
+        $this->assertQueryCount(1, function() use ($result) {
+            $page = $result->paginate(page: 2, limit: 3);
+
+            $this->assertCount(3, $page);
+            $this->assertTrue($page->hasMorePages());
+            $this->assertSame(3, $page->nextPage());
+            $this->assertSame(1, $page->previousPage());
+            $this->assertTrue($page->haveToPaginate());
+        });
+
+        // asking for a total is what costs the extra query
+        $this->assertQueryCount(2, function() use ($result) {
+            $page = $result->paginate(page: 2, limit: 3);
+
+            $this->assertCount(3, $page);
+            $this->assertSame(10, $page->totalCount());
+            $this->assertSame(4, $page->lastPage());
+        });
+    }
+
+    /**
+     * @test
+     */
     public function readonly_specification(): void
     {
         $results = $this->createWithItems(3)->filter(DoctrineSpec::readonly());

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -57,6 +57,36 @@ final class PageTest extends TestCase
     /**
      * @test
      */
+    public function strict_mode_only_counts_when_the_page_is_out_of_range(): void
+    {
+        $counts = 0;
+        $collection = static function() use (&$counts) {
+            return new CallbackCollection(
+                static fn() => yield from \range(1, 10),
+                static function() use (&$counts) {
+                    ++$counts;
+
+                    return 10;
+                },
+            );
+        };
+
+        $page = (new Page($collection(), 2, 3))->strict();
+
+        $this->assertSame(2, $page->currentPage());
+        $this->assertSame([4, 5, 6], \array_values(\iterator_to_array($page)));
+        $this->assertSame(0, $counts, 'an in-range page never counts');
+
+        $page = (new Page($collection(), 99, 3))->strict();
+
+        $this->assertSame(4, $page->currentPage(), 'clamped to the last page');
+        $this->assertSame([10], \array_values(\iterator_to_array($page)));
+        $this->assertSame(1, $counts, 'counted once to find the last page');
+    }
+
+    /**
+     * @test
+     */
     public function knows_when_there_are_no_more_pages(): void
     {
         $page = $this->createPage(\range(1, 10), 4, 3);

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -12,6 +12,7 @@
 namespace Zenstruck\Collection\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Zenstruck\Collection\CallbackCollection;
 use Zenstruck\Collection\LazyCollection;
 use Zenstruck\Collection\Page;
 
@@ -21,6 +22,63 @@ use Zenstruck\Collection\Page;
 final class PageTest extends TestCase
 {
     use CountableIteratorTests;
+
+    /**
+     * @test
+     */
+    public function paging_does_not_count_the_collection(): void
+    {
+        $counts = 0;
+        $collection = new CallbackCollection(
+            static fn() => yield from \range(1, 10),
+            static function() use (&$counts) {
+                ++$counts;
+
+                return 10;
+            },
+        );
+
+        $page = new Page($collection, 2, 3);
+
+        $this->assertSame(2, $page->currentPage());
+        $this->assertCount(3, $page);
+        $this->assertTrue($page->hasMorePages());
+        $this->assertSame(3, $page->nextPage());
+        $this->assertSame(1, $page->previousPage());
+        $this->assertTrue($page->haveToPaginate());
+        $this->assertSame([4, 5, 6], \array_values(\iterator_to_array($page)));
+
+        $this->assertSame(0, $counts);
+
+        $this->assertSame(10, $page->totalCount()); // only now is it counted
+        $this->assertSame(1, $counts);
+    }
+
+    /**
+     * @test
+     */
+    public function knows_when_there_are_no_more_pages(): void
+    {
+        $page = $this->createPage(\range(1, 10), 4, 3);
+
+        $this->assertFalse($page->hasMorePages());
+        $this->assertNull($page->nextPage());
+        $this->assertCount(1, $page);
+        $this->assertSame([10], \array_values(\iterator_to_array($page)));
+    }
+
+    /**
+     * @test
+     */
+    public function a_single_page_collection_does_not_have_to_paginate(): void
+    {
+        $page = $this->createPage(\range(1, 3), 1, 20);
+
+        $this->assertFalse($page->haveToPaginate());
+        $this->assertFalse($page->hasMorePages());
+        $this->assertNull($page->nextPage());
+        $this->assertNull($page->previousPage());
+    }
 
     /**
      * @test
@@ -136,7 +194,8 @@ final class PageTest extends TestCase
 
         $this->assertSame(30, $pager->currentPage());
         $this->assertSame(1, $pager->firstPage());
-        $this->assertSame(31, $pager->nextPage());
+        $this->assertFalse($pager->hasMorePages());
+        $this->assertNull($pager->nextPage());
         $this->assertSame(29, $pager->previousPage());
         $this->assertCount(0, $pager);
         $this->assertSame([], \array_values(\iterator_to_array($pager)));

--- a/tests/PagesTest.php
+++ b/tests/PagesTest.php
@@ -125,7 +125,7 @@ final class PagesTest extends TestCase
         $this->assertNull($collection->get(1)->nextPage());
         $this->assertNull($collection->get(1)->previousPage());
         $this->assertNull($collection->get(99)->strict()->nextPage());
-        $this->assertSame(100, $collection->get(99)->nextPage());
+        $this->assertNull($collection->get(99)->nextPage());
         $this->assertNull($collection->get(99)->strict()->previousPage());
         $this->assertSame(98, $collection->get(99)->previousPage());
     }

--- a/tests/Symfony/Fixture/TestKernel.php
+++ b/tests/Symfony/Fixture/TestKernel.php
@@ -15,6 +15,7 @@ use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
@@ -39,6 +40,7 @@ final class TestKernel extends Kernel
         yield new FrameworkBundle();
         yield new DoctrineBundle();
         yield new ZenstruckFoundryBundle();
+        yield new TwigBundle();
         yield new ZenstruckCollectionBundle();
     }
 
@@ -65,6 +67,8 @@ final class TestKernel extends Kernel
                 ],
             ],
         ]);
+
+        $c->loadFromExtension('twig', ['strict_variables' => true]);
 
         $c->register('logger', NullLogger::class); // disable logging
         $c->register(Service1::class)
@@ -106,5 +110,6 @@ final class TestKernel extends Kernel
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
+        $routes->add('posts', '/posts')->controller('kernel::index');
     }
 }

--- a/tests/Symfony/PagerTemplateTest.php
+++ b/tests/Symfony/PagerTemplateTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/collection package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Collection\Tests\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Zenstruck\Collection\Page;
+
+use function Zenstruck\collect;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class PagerTemplateTest extends KernelTestCase
+{
+    /**
+     * @test
+     */
+    public function simple_pager(): void
+    {
+        $html = $this->render('_simple', new Page(collect(\range(1, 50)), 3, 10));
+
+        $this->assertStringContainsString('<a href="/posts?page=2" rel="prev">Previous</a>', $html);
+        $this->assertStringContainsString('<a href="/posts?page=4" rel="next">Next</a>', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function simple_pager_disables_the_boundaries(): void
+    {
+        $first = $this->render('_simple', new Page(collect(\range(1, 50)), 1, 10));
+
+        $this->assertStringContainsString('<li class="disabled"><span>Previous</span></li>', $first);
+        $this->assertStringContainsString('rel="next"', $first);
+
+        $last = $this->render('_simple', new Page(collect(\range(1, 50)), 5, 10));
+
+        $this->assertStringContainsString('rel="prev"', $last);
+        $this->assertStringContainsString('<li class="disabled"><span>Next</span></li>', $last);
+    }
+
+    /**
+     * @test
+     */
+    public function pagers_render_nothing_for_a_single_page(): void
+    {
+        $this->assertSame('', \trim($this->render('_simple', new Page(collect(\range(1, 5)), 1, 10))));
+        $this->assertSame('', \trim($this->render('_full', new Page(collect(\range(1, 5)), 1, 10))));
+    }
+
+    /**
+     * @test
+     */
+    public function full_pager(): void
+    {
+        $html = $this->render('_full', new Page(collect(\range(1, 50)), 3, 10));
+
+        foreach (\range(1, 5) as $page) {
+            if (3 === $page) {
+                $this->assertStringContainsString('<li class="active"><span>3</span></li>', $html);
+
+                continue;
+            }
+
+            $this->assertStringContainsString(\sprintf('<a href="/posts?page=%d">%d</a>', $page, $page), $html);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function full_pager_windows_large_page_counts(): void
+    {
+        $html = $this->render('_full', new Page(collect(\range(1, 1000)), 50, 10), ['window' => 2]);
+
+        $this->assertStringContainsString('<span>&hellip;</span>', $html);
+        $this->assertStringContainsString('<a href="/posts?page=1">1</a>', $html);
+        $this->assertStringContainsString('<a href="/posts?page=100">100</a>', $html);
+        $this->assertStringContainsString('<a href="/posts?page=49">49</a>', $html);
+        $this->assertStringNotContainsString('page=40', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function existing_query_parameters_are_kept(): void
+    {
+        $html = $this->render('_simple', new Page(collect(\range(1, 50)), 3, 10), [], '/posts?q=symfony&sort=-id');
+
+        $this->assertStringContainsString('q=symfony', $html);
+        $this->assertStringContainsString('sort=-id', $html);
+        $this->assertStringContainsString('page=4', $html);
+    }
+
+    /**
+     * @test
+     */
+    public function the_page_parameter_can_be_renamed(): void
+    {
+        $html = $this->render('_simple', new Page(collect(\range(1, 50)), 3, 10), ['key' => 'p']);
+
+        $this->assertStringContainsString('/posts?p=4', $html);
+    }
+
+    /**
+     * @param array<string,mixed> $context
+     */
+    private function render(string $template, Page $page, array $context = [], string $uri = '/posts'): string
+    {
+        $container = self::getContainer();
+        $request = Request::create($uri);
+        $request->attributes->set('_route', 'posts');
+
+        $container->get('request_stack')->push($request);
+
+        return $container->get('twig')->render(
+            \sprintf('@ZenstruckCollection/Pager/%s.html.twig', $template),
+            ['page' => $page] + $context,
+        );
+    }
+}


### PR DESCRIPTION
Refs #51.

`Page` needed the total to answer even basic questions - `nextPage()` went through `lastPage()` → `totalCount()` → `count()`, so a previous/next pager paid for a `COUNT` over the whole table. It now fetches one item more than fits on the page and uses that extra item's presence to answer the new `hasMorePages()`, discarding it before you see the items. `nextPage()`, `previousPage()` and `haveToPaginate()` are all derived from it.

`totalCount()`, `lastPage()` and `pageCount()` are unchanged - they still count, but only when called. So a previous/next pager counts nothing, and a numbered one counts once.

**Strict mode** got the same treatment: it used to count on every request to validate the page number, and now fetches the requested page first and only counts if that page came back empty. A valid page costs nothing extra; the fallback is paid for only when the requested page really is out of range.

**For #51 specifically:** @jungleman12's exact usage (`paginator.nextPage` and `paginator|length` over 2M rows) now runs no `COUNT` at all, and @seb-jean's diagnosis in that thread was exactly right - the `nextPage()` → `lastPage()` → `totalCount()` chain is what's gone. What this does *not* fix is the `OFFSET` cost you already called out there: deep pages still make the database walk and discard rows. That's still #52's territory, so I left this as a reference rather than a fix.

Also adds `Pager/_simple.html.twig` and `Pager/_full.html.twig` for rendering either mode against a plain `Page`, and Twig becomes a dev dependency so they're actually rendered in tests.

**Behavior change:** `nextPage()` returns `null` for a page past the end where it previously returned the next page number (`paginate(page: 999)` on an 8-page collection used to report `1000`). Two existing assertions covered that and were updated.
